### PR TITLE
dont depend on docker for ECR

### DIFF
--- a/docs/ecr_image_check.md
+++ b/docs/ecr_image_check.md
@@ -1,0 +1,104 @@
+# ECR Image Check Feature
+
+## Overview
+
+Flytekit now supports checking Amazon ECR (Elastic Container Registry) directly for image existence before attempting to build. This feature improves performance and reliability when working with ECR-hosted images by avoiding unnecessary Docker daemon interactions.
+
+## How It Works
+
+When `ImageSpec.exist()` is called to check if an image needs to be built, the following logic is applied:
+
+1. **Check if the registry is ECR**: The registry URL is checked against the ECR pattern (`*.dkr.ecr.*.amazonaws.com`)
+2. **Check AWS CLI availability**: Verify that AWS CLI is installed and credentials are configured
+3. **Try ECR first**: If both conditions are met, use `aws ecr describe-images` to check image existence
+4. **Fallback to Docker**: If ECR check fails or conditions aren't met, fall back to the standard Docker check
+
+## Benefits
+
+- **Performance**: ECR API calls are typically faster than Docker daemon interactions
+- **Reliability**: Avoids Docker daemon connectivity issues when checking ECR images
+- **Seamless fallback**: If ECR check fails for any reason, the system automatically falls back to Docker
+
+## Requirements
+
+For ECR checks to be used, the following must be true:
+
+1. The image registry must be an ECR registry (format: `<account-id>.dkr.ecr.<region>.amazonaws.com`)
+2. AWS CLI must be installed (`aws` command available in PATH)
+3. AWS credentials must be configured (via environment variables, AWS config files, or IAM roles)
+
+## Example Usage
+
+```python
+from flytekit.image_spec.image_spec import ImageSpec
+
+# Create an ImageSpec with ECR registry
+spec = ImageSpec(
+    name="my-ml-model",
+    registry="123456789012.dkr.ecr.us-east-1.amazonaws.com",
+    packages=["numpy", "pandas", "scikit-learn"],
+    python_version="3.9"
+)
+
+# Check if image exists
+# This will:
+# 1. Detect that it's an ECR registry
+# 2. Check if AWS CLI and credentials are available
+# 3. If yes, use AWS CLI to check ECR
+# 4. If no or if check fails, fall back to Docker
+exists = spec.exist()
+
+if exists:
+    print("Image found in ECR, skipping build")
+else:
+    print("Image not found, building...")
+```
+
+## Build Flow
+
+When `ImageSpecBuilder.should_build()` is called:
+
+```
+ImageSpecBuilder.should_build()
+    ↓
+ImageSpec.exist()
+    ↓
+Is ECR registry? → No → Use Docker check
+    ↓ Yes
+AWS CLI available? → No → Use Docker check
+    ↓ Yes
+Check ECR with AWS CLI
+    ↓
+Success? → Yes → Return result
+    ↓ No
+Fall back to Docker check
+```
+
+## Error Handling
+
+The ECR check is designed to be non-disruptive:
+
+- If AWS CLI is not installed: Falls back to Docker
+- If AWS credentials are not configured: Falls back to Docker
+- If ECR API call fails: Falls back to Docker
+- If ECR returns an error: Falls back to Docker
+
+This ensures that the build process continues to work even if ECR checks cannot be performed.
+
+## Debugging
+
+The feature provides colored console output to help debug the check process:
+
+- Blue: "Checking ECR for image..."
+- Green: "Image found in ECR"
+- Yellow: "Image not found in ECR" or "ECR check failed, falling back to Docker"
+
+## Implementation Details
+
+The implementation adds three helper functions:
+
+1. `is_ecr_registry(registry: str) -> bool`: Checks if a registry URL is an ECR registry
+2. `check_aws_cli_and_creds() -> bool`: Verifies AWS CLI and credentials availability
+3. `check_ecr_image_exists(registry: str, repository: str, tag: str) -> Optional[bool]`: Performs the actual ECR check
+
+The `ImageSpec.exist()` method is modified to check these conditions and use ECR when appropriate.

--- a/tests/flytekit/unit/core/image_spec/test_ecr_check.py
+++ b/tests/flytekit/unit/core/image_spec/test_ecr_check.py
@@ -1,0 +1,236 @@
+"""Unit tests for ECR image check functionality."""
+
+import json
+import subprocess
+from unittest import mock
+
+from flytekit.image_spec.image_spec import (
+    ImageSpec,
+    check_aws_cli_and_creds,
+    check_ecr_image_exists,
+    is_ecr_registry,
+)
+
+
+class TestECRHelpers:
+    """Test ECR helper functions."""
+    
+    def test_is_ecr_registry(self):
+        """Test ECR registry detection."""
+        # Valid ECR registries
+        assert is_ecr_registry("123456789012.dkr.ecr.us-east-1.amazonaws.com")
+        assert is_ecr_registry("987654321098.dkr.ecr.eu-west-1.amazonaws.com")
+        assert is_ecr_registry("111111111111.dkr.ecr.ap-southeast-1.amazonaws.com")
+        
+        # Invalid registries
+        assert not is_ecr_registry("docker.io")
+        assert not is_ecr_registry("ghcr.io")
+        assert not is_ecr_registry("localhost:5000")
+        assert not is_ecr_registry("myregistry.com")
+        assert not is_ecr_registry("")
+    
+    @mock.patch('subprocess.run')
+    def test_check_aws_cli_and_creds_success(self, mock_run):
+        """Test AWS CLI check when everything is configured."""
+        # Mock successful responses
+        mock_run.side_effect = [
+            mock.Mock(returncode=0),  # aws --version
+            mock.Mock(returncode=0),  # aws sts get-caller-identity
+        ]
+        
+        assert check_aws_cli_and_creds() is True
+        assert mock_run.call_count == 2
+    
+    @mock.patch('subprocess.run')
+    def test_check_aws_cli_and_creds_no_cli(self, mock_run):
+        """Test AWS CLI check when CLI is not installed."""
+        mock_run.side_effect = FileNotFoundError()
+        assert check_aws_cli_and_creds() is False
+    
+    @mock.patch('subprocess.run')
+    def test_check_aws_cli_and_creds_no_creds(self, mock_run):
+        """Test AWS CLI check when credentials are not configured."""
+        mock_run.side_effect = [
+            mock.Mock(returncode=0),  # aws --version
+            mock.Mock(returncode=1),  # aws sts get-caller-identity fails
+        ]
+        assert check_aws_cli_and_creds() is False
+    
+    @mock.patch('subprocess.run')
+    def test_check_ecr_image_exists_found(self, mock_run):
+        """Test ECR image check when image exists."""
+        mock_result = mock.Mock(
+            returncode=0,
+            stdout=json.dumps({
+                "imageDetails": [
+                    {
+                        "imageTags": ["latest"],
+                        "imageSizeInBytes": 123456789
+                    }
+                ]
+            })
+        )
+        mock_run.return_value = mock_result
+        
+        result = check_ecr_image_exists(
+            "123456789012.dkr.ecr.us-east-1.amazonaws.com",
+            "my-repo",
+            "latest"
+        )
+        assert result is True
+    
+    @mock.patch('subprocess.run')
+    def test_check_ecr_image_exists_not_found(self, mock_run):
+        """Test ECR image check when image doesn't exist."""
+        mock_result = mock.Mock(
+            returncode=1,
+            stderr="ImageNotFoundException"
+        )
+        mock_run.return_value = mock_result
+        
+        result = check_ecr_image_exists(
+            "123456789012.dkr.ecr.us-east-1.amazonaws.com",
+            "my-repo",
+            "latest"
+        )
+        assert result is False
+    
+    @mock.patch('subprocess.run')
+    def test_check_ecr_image_exists_error(self, mock_run):
+        """Test ECR image check when an error occurs."""
+        mock_result = mock.Mock(
+            returncode=1,
+            stderr="Some other error"
+        )
+        mock_run.return_value = mock_result
+        
+        result = check_ecr_image_exists(
+            "123456789012.dkr.ecr.us-east-1.amazonaws.com",
+            "my-repo",
+            "latest"
+        )
+        assert result is None
+    
+    def test_check_ecr_image_exists_invalid_registry(self):
+        """Test ECR image check with invalid registry format."""
+        result = check_ecr_image_exists(
+            "not-an-ecr-registry.com",
+            "my-repo",
+            "latest"
+        )
+        assert result is None
+
+
+class TestImageSpecECR:
+    """Test ImageSpec ECR functionality."""
+    
+    @mock.patch('flytekit.image_spec.image_spec.check_aws_cli_and_creds')
+    @mock.patch('flytekit.image_spec.image_spec.check_ecr_image_exists')
+    @mock.patch('docker.from_env')
+    def test_exist_ecr_success(self, mock_docker, mock_ecr_check, mock_aws_check):
+        """Test exist() method with ECR when image exists."""
+        # Setup mocks
+        mock_aws_check.return_value = True
+        mock_ecr_check.return_value = True
+        
+        # Create ECR ImageSpec
+        spec = ImageSpec(
+            name="my-app",
+            registry="123456789012.dkr.ecr.us-east-1.amazonaws.com",
+            python_version="3.9"
+        )
+        
+        # Check existence
+        result = spec.exist()
+        
+        # Verify ECR was checked, not Docker
+        assert result is True
+        mock_ecr_check.assert_called_once_with(
+            "123456789012.dkr.ecr.us-east-1.amazonaws.com",
+            "my-app",
+            spec.tag
+        )
+        mock_docker.assert_not_called()
+    
+    @mock.patch('flytekit.image_spec.image_spec.check_aws_cli_and_creds')
+    @mock.patch('flytekit.image_spec.image_spec.check_ecr_image_exists')
+    @mock.patch('docker.from_env')
+    def test_exist_ecr_fallback_to_docker(self, mock_docker, mock_ecr_check, mock_aws_check):
+        """Test exist() falls back to Docker when ECR check fails."""
+        # Setup mocks
+        mock_aws_check.return_value = True
+        mock_ecr_check.return_value = None  # ECR check failed
+        
+        # Mock Docker client
+        mock_client = mock.Mock()
+        mock_docker.return_value = mock_client
+        mock_client.images.get_registry_data.return_value = True
+        
+        # Create ECR ImageSpec
+        spec = ImageSpec(
+            name="my-app",
+            registry="123456789012.dkr.ecr.us-east-1.amazonaws.com",
+            python_version="3.9"
+        )
+        
+        # Check existence
+        result = spec.exist()
+        
+        # Verify both ECR and Docker were checked
+        assert result is True
+        mock_ecr_check.assert_called_once()
+        mock_docker.assert_called_once()
+    
+    @mock.patch('flytekit.image_spec.image_spec.check_aws_cli_and_creds')
+    @mock.patch('flytekit.image_spec.image_spec.check_ecr_image_exists')
+    @mock.patch('docker.from_env')
+    def test_exist_non_ecr_registry(self, mock_docker, mock_ecr_check, mock_aws_check):
+        """Test exist() uses Docker directly for non-ECR registries."""
+        # Mock Docker client
+        mock_client = mock.Mock()
+        mock_docker.return_value = mock_client
+        mock_client.images.get_registry_data.return_value = True
+        
+        # Create non-ECR ImageSpec
+        spec = ImageSpec(
+            name="my-app",
+            registry="docker.io/myuser",
+            python_version="3.9"
+        )
+        
+        # Check existence
+        result = spec.exist()
+        
+        # Verify only Docker was checked, not ECR
+        assert result is True
+        mock_ecr_check.assert_not_called()
+        mock_aws_check.assert_not_called()
+        mock_docker.assert_called_once()
+    
+    @mock.patch('flytekit.image_spec.image_spec.check_aws_cli_and_creds')
+    @mock.patch('flytekit.image_spec.image_spec.check_ecr_image_exists')
+    @mock.patch('docker.from_env')
+    def test_exist_ecr_no_aws_cli(self, mock_docker, mock_ecr_check, mock_aws_check):
+        """Test exist() uses Docker when AWS CLI is not available."""
+        # Setup mocks
+        mock_aws_check.return_value = False  # No AWS CLI
+        
+        # Mock Docker client
+        mock_client = mock.Mock()
+        mock_docker.return_value = mock_client
+        mock_client.images.get_registry_data.return_value = True
+        
+        # Create ECR ImageSpec
+        spec = ImageSpec(
+            name="my-app",
+            registry="123456789012.dkr.ecr.us-east-1.amazonaws.com",
+            python_version="3.9"
+        )
+        
+        # Check existence
+        result = spec.exist()
+        
+        # Verify only Docker was checked since AWS CLI not available
+        assert result is True
+        mock_ecr_check.assert_not_called()
+        mock_docker.assert_called_once()


### PR DESCRIPTION
## Why are the changes needed?

This PR introduces a more efficient and reliable way to check for image existence, especially for images hosted on Amazon ECR. Previously, Flytekit relied solely on Docker to check if an image existed, which can be slow or fail if the Docker daemon is unavailable. By directly querying ECR when applicable, we reduce reliance on Docker and improve performance.

## What changes were proposed in this pull request?

This PR implements a new mechanism to check for image existence directly in Amazon ECR before falling back to Docker.

1.  **New Helper Functions**: Added `is_ecr_registry`, `check_aws_cli_and_creds`, and `check_ecr_image_exists` in `flytekit/image_spec/image_spec.py` to:
    *   Identify ECR registry URLs.
    *   Verify AWS CLI installation and credential configuration.
    *   Perform direct ECR image existence checks using `aws ecr describe-images`.
2.  **Modified `ImageSpec.exist()`**: The `exist()` method now:
    *   Prioritizes an ECR check if the image registry is ECR and AWS CLI/credentials are available.
    *   Gracefully falls back to the existing Docker-based check if the ECR check fails or conditions are not met.
3.  **Documentation**: Added `docs/ecr_image_check.md` detailing the feature, its benefits, requirements, and usage.

## How was this patch tested?

Comprehensive unit tests were added in `tests/flytekit/unit/core/image_spec/test_ecr_check.py` to cover:

*   ECR registry detection.
*   AWS CLI and credential availability checks.
*   Successful ECR image existence checks.
*   Fallback scenarios to Docker when ECR checks fail or conditions are not met.
*   Behavior with non-ECR registries.

## Check all the applicable boxes

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [ ] All commits are signed-off.

---

[Slack Thread](https://exa-labs-inc.slack.com/archives/C090Z3VH487/p1752161290040419?thread_ts=1752161290.040419&cid=C090Z3VH487)