### PR TITLE
Add toml configuration file support

### DIFF
--- a/flytekit/clis/sdk_in_container/run.py
+++ b/flytekit/clis/sdk_in_container/run.py
@@ -1,4 +1,5 @@
 import asyncio
+import functools
 import importlib
 import inspect
 import json
@@ -8,11 +9,16 @@ import sys
 import tempfile
 import typing
 import typing as t
+from contextlib import redirect_stdout
 from dataclasses import dataclass, field, fields
 from typing import Iterator, get_args
 
 import rich_click as click
 import yaml
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib
 from click import Context
 from mashumaro.codecs.json import JSONEncoder
 from rich.progress import Progress, TextColumn, TimeElapsedColumn
@@ -957,7 +963,7 @@ class YamlFileReadingCommand(click.RichCommand):
                 ["--inputs-file"],
                 required=False,
                 type=click.Path(exists=True, dir_okay=False, resolve_path=True),
-                help="Path to a YAML | JSON file containing inputs for the workflow.",
+                help="Path to a YAML | JSON | TOML file containing inputs for the workflow.",
             )
         )
         super().__init__(name=name, params=params, callback=callback, help=help)
@@ -971,12 +977,18 @@ class YamlFileReadingCommand(click.RichCommand):
                 try:
                     inputs = json.loads(f)
                 except json.JSONDecodeError as e:
-                    raise click.BadParameter(
-                        message=f"Could not load the inputs file. Please make sure it is a valid JSON or YAML file."
-                        f"\n json error: {e},"
-                        f"\n yaml error: {yaml_e}",
-                        param_hint="--inputs-file",
-                    )
+                    json_e = e
+                    try:
+                        inputs = tomllib.loads(f)
+                    except Exception as e:
+                        toml_e = e
+                        raise click.BadParameter(
+                            message=f"Could not load the inputs file. Please make sure it is a valid JSON, YAML, or TOML file."
+                            f"\n json error: {json_e},"
+                            f"\n yaml error: {yaml_e},"
+                            f"\n toml error: {toml_e}",
+                            param_hint="--inputs-file",
+                        )
 
             return inputs
 

--- a/tests/flytekit/unit/cli/pyflyte/my_wf_input.toml
+++ b/tests/flytekit/unit/cli/pyflyte/my_wf_input.toml
@@ -1,0 +1,45 @@
+a = 1
+b = "Hello"
+c = 1.1
+e = [1, 2, 3]
+g = "tests/flytekit/unit/cli/pyflyte/testdata/df.parquet"
+h = true
+i = "2020-05-01"
+j = "20H"
+k = "RED"
+p = "None"
+q = "tests/flytekit/unit/cli/pyflyte/testdata"
+remote = "tests/flytekit/unit/cli/pyflyte/testdata"
+image = "tests/flytekit/unit/cli/pyflyte/testdata"
+
+[d]
+i = 1
+a = ["h", "e"]
+
+[f]
+x = 1.0
+y = 2.0
+
+[l]
+hello = "world"
+
+[m]
+a = "b"
+c = "d"
+
+[[n]]
+x = "tests/flytekit/unit/cli/pyflyte/testdata/df.parquet"
+
+[o]
+x = ["tests/flytekit/unit/cli/pyflyte/testdata/df.parquet"]
+
+[[r]]
+i = 1
+a = ["h", "e"]
+
+[s.x]
+i = 1
+a = ["h", "e"]
+
+[t]
+i = [{i = 1, a = ["h", "e"]}]

--- a/tests/flytekit/unit/cli/pyflyte/test_run.py
+++ b/tests/flytekit/unit/cli/pyflyte/test_run.py
@@ -299,6 +299,17 @@ def test_all_types_with_yaml_input():
     assert result.exit_code == 0, result.stdout
 
 
+def test_all_types_with_toml_input():
+    runner = CliRunner()
+
+    result = runner.invoke(
+        pyflyte.main,
+        ["run", os.path.join(DIR_NAME, "workflow.py"), "my_wf", "--inputs-file", os.path.join(os.path.dirname(os.path.realpath(__file__)), "my_wf_input.toml")],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0, result.stdout
+
+
 def test_all_types_with_pipe_input(monkeypatch):
     runner = CliRunner()
     input= str(json.load(open(os.path.join(os.path.dirname(os.path.realpath(__file__)), "my_wf_input.json"),"r")))


### PR DESCRIPTION
```
## Tracking issue
<!-- Remove this section if not applicable -->

## Why are the changes needed?

Currently, `pyflyte run` supports passing inputs via JSON and YAML files. Adding TOML support provides more flexibility for users who manage configurations in TOML format, aligning with existing capabilities and potentially simplifying local development workflows by allowing direct use of TOML config files as inputs. This also addresses a desire to avoid full image rebuilds when only config files change, by enabling them to be passed as inputs.

## What changes were proposed in this pull request?

This PR extends `pyflyte run` to support TOML files for the `--inputs-file` argument.
- Integrated `tomllib` (or `tomli` for Python < 3.11) for parsing TOML files.
- Modified the `load_inputs` function in `YamlFileReadingCommand` to attempt parsing as TOML if JSON and YAML parsing fail.
- Updated the `--inputs-file` help text and error messages to reflect TOML support.
- Added a new TOML input test file (`my_wf_input.toml`) and a corresponding unit test (`test_all_types_with_toml_input`) to verify the functionality.

## How was this patch tested?

New unit tests were added in `tests/flytekit/unit/cli/pyflyte/test_run.py` to cover the TOML input parsing functionality.

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

Related to the existing JSON/YAML support introduced in flyteorg/flytekit#1606.

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
```

---

[Slack Thread](https://exa-labs-inc.slack.com/archives/C06SWF577MX/p1753383947893849?thread_ts=1753383947.893849&cid=C06SWF577MX) • [Open in Web](https://www.cursor.com/agents?id=bc-97505f75-87fd-41ce-a08d-c197565aea2d) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-97505f75-87fd-41ce-a08d-c197565aea2d)