### PR TITLE
[flytekit]: Add multi-arch Nix build support with manifest creation

### DIFF
--- a/flytekit/image_spec/default_builder.py
+++ b/flytekit/image_spec/default_builder.py
@@ -944,12 +944,15 @@ class DefaultImageBuilder(ImageSpecBuilder):
             platform, arch_tag = task
             click.secho(f"Building Nix image for {platform} with tag {arch_tag}", fg="blue")
 
+            # Note: We do NOT use --push here because the Dockerfile already handles
+            # pushing the nix2container image via `nix run .#docker.copyTo`.
+            # Using --push would push the Ubuntu-based build image instead of the
+            # nix2container image, which would overwrite the correct image.
             command = [
                 "depot",
                 "build",
                 "--tag",
                 arch_tag,
-                "--push",
                 "--platform",
                 platform,
                 "--project",

--- a/flytekit/image_spec/default_builder.py
+++ b/flytekit/image_spec/default_builder.py
@@ -191,11 +191,9 @@ RUN groupadd -g 30000 nixbld && \
 # Install Nix using cache mount so it persists across builds
 # Use --init none since we're in a container and don't need systemd
 # sandbox=false since we're in a container without proper namespace support
-# First uninstall any existing Nix installation to avoid conflicts with different planner settings
+# Remove any existing Nix installation to avoid conflicts with cached builds
 RUN --mount=type=cache,target=/nix,id=nix-determinate \
-    if [ -f /nix/receipt.json ]; then \
-        /nix/nix-installer uninstall --no-confirm || true; \
-    fi && \
+    rm -rf /nix/* && \
     curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | \
         sh -s -- install linux \
         --determinate \

--- a/flytekit/image_spec/default_builder.py
+++ b/flytekit/image_spec/default_builder.py
@@ -949,6 +949,7 @@ class DefaultImageBuilder(ImageSpecBuilder):
                 "build",
                 "--tag",
                 arch_tag,
+                "--push",
                 "--platform",
                 platform,
                 "--project",

--- a/flytekit/image_spec/default_builder.py
+++ b/flytekit/image_spec/default_builder.py
@@ -7,10 +7,11 @@ import sys
 import tempfile
 import time
 import warnings
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 from string import Template
 from subprocess import run
-from typing import ClassVar, List, NamedTuple
+from typing import ClassVar, List, NamedTuple, Tuple
 
 import click
 import toml
@@ -922,20 +923,25 @@ class DefaultImageBuilder(ImageSpecBuilder):
             return image_spec.image_name()
 
     def _build_multi_arch_nix(self, image_spec: ImageSpec, tmp_dir: str, platforms: List[str], push: bool) -> str:
-        """Build multi-arch Nix images with architecture-specific tags, then create a manifest.
+        """Build multi-arch Nix images with architecture-specific tags in parallel, then create a manifest.
 
         For each platform (e.g., linux/amd64, linux/arm64), this method:
-        1. Triggers a Depot build with an architecture-specific tag postfix
+        1. Triggers Depot builds in parallel with architecture-specific tag postfixes
         2. After all builds complete, creates a multi-arch manifest pointing to both images
         """
         base_image_name = image_spec.image_name()
         arch_images = []
+        build_tasks = []
 
         for platform in platforms:
             arch = platform.split("/")[-1]  # Extract arch from "linux/amd64" -> "amd64"
             arch_tag = f"{base_image_name}-{arch}"
             arch_images.append(arch_tag)
+            build_tasks.append((platform, arch_tag))
 
+        def run_build(task: Tuple[str, str]) -> Tuple[str, bool, str]:
+            """Run a single Depot build and return (arch_tag, success, error_msg)."""
+            platform, arch_tag = task
             click.secho(f"Building Nix image for {platform} with tag {arch_tag}", fg="blue")
 
             command = [
@@ -952,7 +958,28 @@ class DefaultImageBuilder(ImageSpecBuilder):
 
             concat_command = " ".join(command)
             click.secho(f"Run command: {concat_command}", fg="blue")
-            run(command, check=True)
+            try:
+                run(command, check=True)
+                click.secho(f"Build completed for {platform}", fg="green")
+                return (arch_tag, True, "")
+            except subprocess.CalledProcessError as e:
+                return (arch_tag, False, str(e))
+
+        # Run all builds in parallel
+        click.secho(f"Starting parallel builds for {len(build_tasks)} platforms...", fg="blue")
+        with ThreadPoolExecutor(max_workers=len(build_tasks)) as executor:
+            futures = {executor.submit(run_build, task): task for task in build_tasks}
+            results = []
+            for future in as_completed(futures):
+                results.append(future.result())
+
+        # Check for failures
+        failures = [(tag, err) for tag, success, err in results if not success]
+        if failures:
+            error_msgs = [f"{tag}: {err}" for tag, err in failures]
+            raise RuntimeError(f"Multi-arch builds failed:\n" + "\n".join(error_msgs))
+
+        click.secho(f"All {len(build_tasks)} builds completed successfully", fg="green")
 
         if push and image_spec.registry:
             self._create_multi_arch_manifest(base_image_name, arch_images)

--- a/flytekit/image_spec/default_builder.py
+++ b/flytekit/image_spec/default_builder.py
@@ -182,7 +182,7 @@ RUN apt-get update -y && \
 
 # Create nixbld group and users required by the Nix installer
 # The Determinate Systems installer expects these to exist
-# Note: $$ is used to escape $ for Python Template substitution
+# Note: double-dollar is used to escape dollar signs for Python Template substitution
 RUN groupadd -g 30000 nixbld && \
     for i in $$(seq 1 32); do \
         useradd -u $$((30000 + i)) -g nixbld -G nixbld -d /var/empty -s /sbin/nologin nixbld$$i; \

--- a/flytekit/image_spec/default_builder.py
+++ b/flytekit/image_spec/default_builder.py
@@ -5,6 +5,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
+import time
 import warnings
 from pathlib import Path
 from string import Template
@@ -882,6 +883,13 @@ class DefaultImageBuilder(ImageSpecBuilder):
             tmp_path = Path(tmp_dir)
             create_docker_context(image_spec, tmp_path)
 
+            # Check if this is a multi-arch Nix build
+            platforms = [p.strip() for p in image_spec.platform.split(",")]
+            is_multi_arch = len(platforms) > 1
+
+            if image_spec.nix and is_multi_arch and image_spec.use_depot:
+                return self._build_multi_arch_nix(image_spec, tmp_dir, platforms, push)
+
             if image_spec.use_depot:
                 command = [
                     "depot",
@@ -912,3 +920,81 @@ class DefaultImageBuilder(ImageSpecBuilder):
             click.secho(f"Run command: {concat_command} ", fg="blue")
             run(command, check=True)
             return image_spec.image_name()
+
+    def _build_multi_arch_nix(self, image_spec: ImageSpec, tmp_dir: str, platforms: List[str], push: bool) -> str:
+        """Build multi-arch Nix images with architecture-specific tags, then create a manifest.
+
+        For each platform (e.g., linux/amd64, linux/arm64), this method:
+        1. Triggers a Depot build with an architecture-specific tag postfix
+        2. After all builds complete, creates a multi-arch manifest pointing to both images
+        """
+        base_image_name = image_spec.image_name()
+        arch_images = []
+
+        for platform in platforms:
+            arch = platform.split("/")[-1]  # Extract arch from "linux/amd64" -> "amd64"
+            arch_tag = f"{base_image_name}-{arch}"
+            arch_images.append(arch_tag)
+
+            click.secho(f"Building Nix image for {platform} with tag {arch_tag}", fg="blue")
+
+            command = [
+                "depot",
+                "build",
+                "--tag",
+                arch_tag,
+                "--platform",
+                platform,
+                "--project",
+                "bf5bv9t2mj",
+                tmp_dir,
+            ]
+
+            concat_command = " ".join(command)
+            click.secho(f"Run command: {concat_command}", fg="blue")
+            run(command, check=True)
+
+        if push and image_spec.registry:
+            self._create_multi_arch_manifest(base_image_name, arch_images)
+
+        return base_image_name
+
+    def _create_multi_arch_manifest(self, manifest_tag: str, arch_images: List[str]) -> None:
+        """Create a multi-arch manifest that points to architecture-specific images.
+
+        Uses `docker buildx imagetools create` to combine architecture-specific images
+        into a single multi-arch manifest list.
+        """
+        click.secho(f"Creating multi-arch manifest: {manifest_tag}", fg="blue")
+
+        # Verify all architecture images exist before creating manifest
+        for arch_image in arch_images:
+            click.secho(f"Verifying image exists: {arch_image}", fg="cyan")
+            max_attempts = 6
+            for attempt in range(1, max_attempts + 1):
+                result = run(
+                    ["docker", "buildx", "imagetools", "inspect", arch_image],
+                    capture_output=True,
+                    text=True,
+                )
+                if result.returncode == 0:
+                    click.secho(f"Found image: {arch_image}", fg="green")
+                    break
+                if attempt == max_attempts:
+                    raise RuntimeError(f"Image {arch_image} not found after {max_attempts} attempts")
+                click.secho(f"Attempt {attempt}/{max_attempts}: Image not found, waiting 10s...", fg="yellow")
+                time.sleep(10)
+
+        command = [
+            "docker",
+            "buildx",
+            "imagetools",
+            "create",
+            "--tag",
+            manifest_tag,
+        ] + arch_images
+
+        concat_command = " ".join(command)
+        click.secho(f"Run command: {concat_command}", fg="blue")
+        run(command, check=True)
+        click.secho(f"Multi-arch manifest created: {manifest_tag}", fg="green")

--- a/flytekit/image_spec/default_builder.py
+++ b/flytekit/image_spec/default_builder.py
@@ -201,10 +201,12 @@ WORKDIR /build
 # Build with cache mount - reuses the same cache across builds
 # Note: We use shell form (not exec form) so that ARG variables are expanded
 # Source nix profile and run nix directly (no daemon needed with build-users-group = "")
+# Remove /homeless-shelter to avoid "home directory exists" error when sandbox=false
 RUN --mount=type=bind,source=.,target=/build/ \
     --mount=type=cache,target=/nix,id=nix-determinate \
     --mount=type=cache,target=/root/.cache/nix,id=nix-git-cache \
     --mount=type=cache,target=/var/lib/containers/cache,id=container-cache \
+    rm -rf /homeless-shelter && \
     . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh && \
     nix run .#docker.copyTo -- "docker://$${IMAGE_NAME}" --dest-creds "AWS:$${ECR_TOKEN}" \
     --image-parallel-copies 32

--- a/flytekit/image_spec/default_builder.py
+++ b/flytekit/image_spec/default_builder.py
@@ -191,7 +191,11 @@ RUN groupadd -g 30000 nixbld && \
 # Install Nix using cache mount so it persists across builds
 # Use --init none since we're in a container and don't need systemd
 # sandbox=false since we're in a container without proper namespace support
+# First uninstall any existing Nix installation to avoid conflicts with different planner settings
 RUN --mount=type=cache,target=/nix,id=nix-determinate \
+    if [ -f /nix/receipt.json ]; then \
+        /nix/nix-installer uninstall --no-confirm || true; \
+    fi && \
     curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | \
         sh -s -- install linux \
         --determinate \

--- a/flytekit/image_spec/default_builder.py
+++ b/flytekit/image_spec/default_builder.py
@@ -182,9 +182,10 @@ RUN apt-get update -y && \
 
 # Create nixbld group and users required by the Nix installer
 # The Determinate Systems installer expects these to exist
+# Note: $$ is used to escape $ for Python Template substitution
 RUN groupadd -g 30000 nixbld && \
-    for i in $(seq 1 32); do \
-        useradd -u $((30000 + i)) -g nixbld -G nixbld -d /var/empty -s /sbin/nologin nixbld$i; \
+    for i in $$(seq 1 32); do \
+        useradd -u $$((30000 + i)) -g nixbld -G nixbld -d /var/empty -s /sbin/nologin nixbld$$i; \
     done
 
 # Install Nix using cache mount so it persists across builds

--- a/flytekit/image_spec/default_builder.py
+++ b/flytekit/image_spec/default_builder.py
@@ -191,9 +191,10 @@ RUN groupadd -g 30000 nixbld && \
 # Install Nix using cache mount so it persists across builds
 # Use --init none since we're in a container and don't need systemd
 # sandbox=false since we're in a container without proper namespace support
-# Remove any existing Nix installation to avoid conflicts with cached builds
+# Thoroughly clean any existing Nix installation to avoid conflicts with cached builds
+# Use find to ensure all files including hidden ones are removed
 RUN --mount=type=cache,target=/nix,id=nix-determinate \
-    rm -rf /nix/* && \
+    find /nix -mindepth 1 -delete 2>/dev/null || true && \
     curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | \
         sh -s -- install linux \
         --determinate \


### PR DESCRIPTION
## Why are the changes needed?

When building Nix-based container images, we need support for multi-architecture builds (amd64 and arm64) to run on different hardware. Currently, Nix builds only support single-platform builds. This PR adds the ability to build for multiple architectures and create a unified multi-arch manifest.

## What changes were proposed in this pull request?

Added multi-arch Nix build support to `DefaultImageBuilder` in `flytekit/image_spec/default_builder.py`:

1. **Multi-arch detection**: When `platform` contains multiple architectures (e.g., `"linux/amd64,linux/arm64"`), the build is treated as multi-arch
2. **Parallel architecture-specific builds**: For each platform, triggers a separate Depot build with an architecture-specific tag postfix (e.g., `myimage:tag-amd64`, `myimage:tag-arm64`). Builds run in parallel using `ThreadPoolExecutor`
3. **Manifest creation**: After all architecture builds complete, creates a multi-arch manifest using `docker buildx imagetools create` that points to both ECR images
4. **Architecture verification in `exist()`**: Added `check_ecr_image_architectures()` function and updated `ImageSpec.exist()` to verify that cached images have ALL required architectures before skipping builds

The implementation follows the pattern from the monorepo's `nix-build.yaml` workflow.

### Updates since last revision
- Changed from sequential to **parallel builds** using `ThreadPoolExecutor` for faster multi-arch builds
- **Fixed missing `--push` flag** in Depot build command - images were being built but not pushed to ECR
- Added **architecture verification** in `exist()` method to detect when a single-arch image is cached instead of a proper multi-arch manifest

### Key review points
- [ ] Verify the `--push` flag is correctly placed in the Depot build command (line ~952)
- [ ] Check architecture parsing in `check_ecr_image_architectures()` - relies on parsing `docker buildx imagetools inspect` output
- [ ] Verify the multi-arch detection logic in `exist()` correctly identifies missing architectures
- [ ] Check if the retry logic (6 attempts, 10s wait) for image verification is appropriate
- [ ] Review thread safety of `click.secho` calls during parallel builds (output may interleave)
- [ ] Note: Depot project ID `bf5bv9t2mj` is hardcoded - this is Exa-specific

## How was this patch tested?

- Code passes ruff linting and formatting checks
- No unit tests were added - the changes involve subprocess calls to `depot` and `docker buildx` which are difficult to unit test without mocking
- Integration testing via monorepo PR #13304 which runs the `nix-multiarch-test` workflow

## Check all the applicable boxes

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

- Monorepo PR: https://github.com/exa-labs/monorepo/pull/13304

## Link to Devin run
https://app.devin.ai/sessions/98b686346e954acf9a44d621ec151cfd

Requested by: @Carlos-Marques