### PR TITLE
[image-spec]: revert nix-native image builder (#35) and cross-build support (#43)

### DIFF
--- a/flytekit/image_spec/default_builder.py
+++ b/flytekit/image_spec/default_builder.py
@@ -157,6 +157,49 @@ RUN mkdir -p $$HOME && \
     echo "export PATH=$$PATH" >> $$HOME/.profile
 """)
 
+NIX_DOCKER_FILE_TEMPLATE = Template("""\
+# Use Ubuntu as base instead of nixpkgs/nix for better compatibility
+FROM ubuntu:24.04
+
+# Install curl and other basic dependencies needed for the installer
+RUN apt-get update -y && \
+    apt-get install -y \
+        curl \
+        sudo \
+        xz-utils \
+        git \
+        ca-certificates \
+        rsync && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install Nix using cache mount so it persists across builds
+RUN --mount=type=cache,target=/nix,id=nix-determinate \
+    curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | \
+        sh -s -- install linux \
+        --determinate \
+        --extra-conf "sandbox = true" \
+        --extra-conf "max-substitution-jobs = 256" \
+        --extra-conf "http-connections = 256" \
+        --extra-conf "download-buffer-size = 1073741824" \
+        --init none \
+        --no-confirm
+
+# Create a working directory for the build
+WORKDIR /build
+
+# Build with cache mount - reuses the same cache across builds
+RUN --mount=type=bind,source=.,target=/build/ \
+    --mount=type=cache,target=/nix,id=nix-determinate \
+    --mount=type=cache,target=/root/.cache/nix,id=nix-git-cache \
+    --mount=type=cache,target=/var/lib/containers/cache,id=container-cache \
+    . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh && \
+    nix run .#docker.copyTo -- docker://$IMAGE_NAME --dest-creds "AWS:$ECR_TOKEN" \
+    --image-parallel-copies 32 \
+    --dest-creds "AWS:$ECR_TOKEN"
+""")
+
+
 def get_flytekit_for_pypi():
     """Get flytekit version on PyPI."""
     from flytekit import __version__
@@ -728,7 +771,16 @@ RUN --mount=type=cache,sharing=locked,mode=0777,target=/root/.cache/uv,id=uv \\
         uv_venv_install = ""
 
     if image_spec.nix:
-        return
+        docker_content = NIX_DOCKER_FILE_TEMPLATE.substitute(
+            IMAGE_NAME=image_spec.image_name(),
+            COPY_LOCAL_PACKAGES=copy_local_packages,
+            ECR_TOKEN=subprocess.run(
+                ["aws", "ecr", "get-login-password", "--region", "us-west-2"],
+                capture_output=True,
+                text=True,
+                check=True,
+            ).stdout.strip(),
+        )
     else:
         docker_content = DOCKER_FILE_TEMPLATE.substitute(
             UV_PYTHON_INSTALL_COMMAND=uv_python_install_command,
@@ -785,6 +837,8 @@ class DefaultImageBuilder(ImageSpecBuilder):
         )
 
     def _build_image(self, image_spec: ImageSpec, *, push: bool = True) -> str:
+        # For testing, set `push=False`` to just build the image locally and not push to
+        # registry
         unsupported_parameters = [
             name
             for name, value in vars(image_spec).items()
@@ -794,92 +848,67 @@ class DefaultImageBuilder(ImageSpecBuilder):
             msg = f"The following parameters are unsupported and ignored: {unsupported_parameters}"
             warnings.warn(msg, UserWarning, stacklevel=2)
 
+        # Check if build tools are available
         import shutil
+
+        if image_spec.use_depot:
+            if not shutil.which("depot"):
+                raise RuntimeError(
+                    "Depot is not installed or not in PATH. "
+                    "Please install depot (https://depot.dev/docs/installation) or use Docker instead by setting use_depot=False"
+                )
+        else:
+            if not shutil.which("docker"):
+                raise RuntimeError(
+                    "Docker is not installed or not in PATH. "
+                    "Please install Docker (https://docs.docker.com/get-docker/) or use depot by setting use_depot=True"
+                )
+
+            # Check if Docker daemon is running
+            try:
+                result = run(["docker", "info"], capture_output=True, text=True)
+                if result.returncode != 0:
+                    raise RuntimeError(
+                        f"Docker daemon is not running or not accessible. Error: {result.stderr}\n"
+                        "Please start Docker daemon or use depot by setting use_depot=True"
+                    )
+            except Exception as e:
+                raise RuntimeError(
+                    f"Failed to check Docker daemon status: {str(e)}\n"
+                    "Please ensure Docker is properly installed and running, or use depot by setting use_depot=True"
+                )
 
         with tempfile.TemporaryDirectory() as tmp_dir:
             tmp_path = Path(tmp_dir)
             create_docker_context(image_spec, tmp_path)
 
-            if image_spec.nix:
-                if not shutil.which("nix"):
-                    raise RuntimeError(
-                        "Nix is not installed or not in PATH. "
-                        "Please install Nix (https://nixos.org/download)"
-                    )
-                platform_to_nix_system = {
-                    "linux/amd64": "x86_64-linux",
-                    "linux/arm64": "aarch64-linux",
-                }
-                nix_system = platform_to_nix_system.get(image_spec.platform)
-                if not nix_system:
-                    raise RuntimeError(
-                        f"Unsupported platform for nix builds: {image_spec.platform}. "
-                        f"Supported: {', '.join(platform_to_nix_system.keys())}"
-                    )
-                if push and image_spec.registry:
-                    ecr_token = subprocess.run(
-                        ["aws", "ecr", "get-login-password", "--region", "us-west-2"],
-                        capture_output=True, text=True, check=True,
-                    ).stdout.strip()
-                    command = [
-                        "nix", "run",
-                        f"path:{tmp_dir}#packages.{nix_system}.docker.copyTo", "--",
-                        f"docker://{image_spec.image_name()}",
-                        "--dest-creds", f"AWS:{ecr_token}",
-                        "--image-parallel-copies", "32",
-                    ]
-                else:
-                    command = ["nix", "build", f"path:{tmp_dir}#packages.{nix_system}.docker"]
-            elif image_spec.use_depot:
-                if not shutil.which("depot"):
-                    raise RuntimeError(
-                        "Depot is not installed or not in PATH. "
-                        "Please install depot (https://depot.dev/docs/installation) or use Docker instead by setting use_depot=False"
-                    )
+            if image_spec.use_depot:
                 command = [
-                    "depot", "build",
-                    "--tag", f"{image_spec.image_name()}",
-                    "--platform", image_spec.platform,
+                    "depot",
+                    "build",
+                    "--tag",
+                    f"{image_spec.image_name()}",
+                    "--platform",
+                    image_spec.platform,
                 ]
-                if image_spec.registry and push:
-                    command.append("--push")
-                command.append(tmp_dir)
+                if image_spec.nix:
+                    command.extend(["--project", "bf5bv9t2mj"])
             else:
-                if not shutil.which("docker"):
-                    raise RuntimeError(
-                        "Docker is not installed or not in PATH. "
-                        "Please install Docker (https://docs.docker.com/get-docker/)"
-                    )
-                try:
-                    result = run(["docker", "info"], capture_output=True, text=True)
-                except Exception as e:
-                    raise RuntimeError(
-                        f"Failed to check Docker daemon status: {str(e)}\n"
-                        "Please ensure Docker is properly installed and running."
-                    )
-                if result.returncode != 0:
-                    raise RuntimeError(
-                        f"Docker daemon is not running or not accessible. Error: {result.stderr}\n"
-                        "Please start Docker daemon."
-                    )
                 command = [
-                    "docker", "image", "build",
-                    "--tag", f"{image_spec.image_name()}",
-                    "--platform", image_spec.platform,
+                    "docker",
+                    "image",
+                    "build",
+                    "--tag",
+                    f"{image_spec.image_name()}",
+                    "--platform",
+                    image_spec.platform,
                 ]
-                if image_spec.registry and push:
-                    command.append("--push")
-                command.append(tmp_dir)
 
-            log_command = list(command)
-            for i, arg in enumerate(log_command):
-                if arg == "--dest-creds" and i + 1 < len(log_command):
-                    log_command[i + 1] = "[REDACTED]"
-            click.secho(f"Run command: {' '.join(log_command)} ", fg="blue")
-            result = run(command)
-            if result.returncode != 0:
-                raise RuntimeError(
-                    f"Build command failed with exit code {result.returncode}: "
-                    f"{' '.join(log_command)}"
-                )
+            if image_spec.registry and push and not image_spec.nix:
+                command.append("--push")
+            command.append(tmp_dir)
+
+            concat_command = " ".join(command)
+            click.secho(f"Run command: {concat_command} ", fg="blue")
+            run(command, check=True)
             return image_spec.image_name()

--- a/flytekit/image_spec/image_spec.py
+++ b/flytekit/image_spec/image_spec.py
@@ -248,7 +248,7 @@ class ImageSpec:
             If the option is set by the user, then that option is of course used.
         copy: List of files/directories to copy to /root. e.g. ["src/file1.txt", "src/file2.txt"]
         python_exec: Python executable to use for install packages
-        use_depot: Whether to use depot to build the image. If True, the image will be built using depot. If False, the image will be built using docker. Defaults to False (docker).
+        use_depot: Whether to use depot to build the image. If True, the image will be built using depot. If False, the image will be built using docker.
         uv_export_args: Extra arguments to pass to uv export.
         vendor_local: Whether to vendor the local project into the image.
         nix: Whether to use nix to build the image. If True, the image will be built using nix. If False, the image will be built using docker.
@@ -280,7 +280,7 @@ class ImageSpec:
     copy: Optional[List[str]] = None
     python_exec: Optional[str] = None
     install_project: Optional[bool] = False
-    use_depot: Optional[bool] = False
+    use_depot: Optional[bool] = True
     uv_export_args: str = ""
     vendor_local: Optional[bool] = True
     nix: Optional[bool] = False

--- a/tests/flytekit/unit/core/image_spec/test_error_handling.py
+++ b/tests/flytekit/unit/core/image_spec/test_error_handling.py
@@ -79,6 +79,7 @@ class TestBuildErrorHandling:
         # Verify
         assert "Docker is not installed or not in PATH" in str(exc_info.value)
         assert "https://docs.docker.com/get-docker/" in str(exc_info.value)
+        assert "use_depot=True" in str(exc_info.value)
     
     @patch('shutil.which')
     @patch('flytekit.image_spec.default_builder.run')
@@ -102,6 +103,7 @@ class TestBuildErrorHandling:
         
         # Verify
         assert "Docker daemon is not running" in str(exc_info.value)
+        assert "use_depot=True" in str(exc_info.value)
     
     @patch('shutil.which')
     def test_depot_not_installed(self, mock_which):


### PR DESCRIPTION
## Tracking issue

Reverts #35 and #43.

## Why are the changes needed?

Reverting the nix-native image builder changes (#35) and the cross-build support (#43, which depended on #35) per request. This restores the previous depot-based build path for `nix=True` ImageSpec builds.

## What changes were proposed in this pull request?

Two `git revert -m 1` operations in reverse chronological order:
1. Revert of #43 (cross-platform nix build support via remote builders)
2. Revert of #35 (nix-native image builder, churn depot dependency)

This restores:
- `use_depot` default back to `True`
- `NIX_DOCKER_FILE_TEMPLATE` (Docker-in-Docker approach: installs nix inside Ubuntu container, runs `nix run .#docker.copyTo`)
- Depot-based build path when `nix=True` (uses `--project bf5bv9t2mj`)
- Original error messages suggesting `use_depot=True` as alternative
- `run(command, check=True)` instead of manual returncode + credential redaction

## How was this patch tested?

Mechanical revert of two merge commits. Existing unit tests updated to match restored error messages.

## ⚠️ Human review checklist

- [ ] **PR #43 also reverted**: Cross-build support (#43) was built on top of #35's nix-native changes, so it had to be reverted too. Confirm this is acceptable.
- [ ] **`use_depot` default is `True` again**: Any `ImageSpec` without explicit `use_depot=False` will use depot. Verify this is the desired behavior.
- [ ] **ECR credential exposure restored**: The reverted code passes ECR tokens via `run(command, check=True)` which can leak credentials in `CalledProcessError.cmd` on failure. #35 had added redaction logic that is now removed.
- [ ] **Duplicate `--dest-creds`** in `NIX_DOCKER_FILE_TEMPLATE` (line ~196) — pre-existing issue restored by this revert.

## Related PRs

- #35 (reverted): [image-spec]: nix-native image builder, churn depot dependency
- #43 (reverted): cross-platform nix build support via remote builders
- Companion monorepo PR: [exa-labs/monorepo#17592](https://github.com/exa-labs/monorepo/pull/17592) (depot removal — may also need reverting)

---

Link to Devin run: https://app.devin.ai/sessions/af4653767caf4f7aa96c81f4244e94a6
Requested by: @jld-adriano
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/exa-labs/flytekit/pull/45" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
