### PR TITLE
fix(image-spec): discover transitive nix flake path deps from flake.lock

### DIFF
--- a/flytekit/image_spec/default_builder.py
+++ b/flytekit/image_spec/default_builder.py
@@ -390,32 +390,22 @@ def _copy_local_packages_and_update_lock(image_spec: ImageSpec, tmp_dir: Path):
         flake_path_replacements = {}
         inputs = discover_nix_flake_path_inputs(lock_dir, flake_content)
 
-        # Track already-discovered paths to avoid duplicates when scanning flake.lock
-        already_discovered = {str(inp.src_path) for inp in inputs}
-
         # Also discover transitive path deps from flake.lock (e.g. minos2_rust -> rust-exautils)
+        already_discovered = {str(inp.src_path) for inp in inputs}
         transitive_inputs = discover_nix_flake_lock_path_inputs(
             lock_dir, flake_lock_content, already_discovered
         )
-        all_nix_inputs = inputs + transitive_inputs
 
-        for inp in all_nix_inputs:
-            full_spec = inp.full_spec
-            old_rel_path = inp.old_rel_path
+        def _copy_nix_input(inp):
             src_path = inp.src_path
-
             if not src_path.exists():
                 raise ValueError(f"Nix flake path input does not exist: {src_path}")
-
             git_root = _find_git_root(str(src_path))
             if git_root is None:
                 raise ValueError(f"Could not find git root for Nix flake path input: {src_path}")
-
             rel_path = os.path.relpath(path=str(src_path), start=str(git_root))
             target_path = local_packages_dir / rel_path
             target_path.parent.mkdir(parents=True, exist_ok=True)
-
-            # Copy with ignore patterns
             if src_path.is_dir():
                 ignore_group_dep = IgnoreGroup(str(src_path), [GitIgnore, DockerIgnore, StandardIgnore])
                 files_to_copy_dep, _ = ls_files(
@@ -431,15 +421,21 @@ def _copy_local_packages_and_update_lock(image_spec: ImageSpec, tmp_dir: Path):
                     shutil.copy2(file_to_copy, file_dst)
             else:
                 shutil.copy2(str(src_path), str(target_path))
+            return rel_path
 
+        # Copy and rewrite direct inputs (referenced in flake.nix)
+        for inp in inputs:
+            rel_path = _copy_nix_input(inp)
             new_rel_path = f"local_packages/{rel_path}"
+            flake_content = flake_content.replace(inp.full_spec, f"path:{new_rel_path}")
+            flake_path_replacements[inp.old_rel_path] = new_rel_path
 
-            # Update flake.nix content in-memory (only for direct inputs found in flake.nix)
-            if inp in inputs:
-                flake_content = flake_content.replace(full_spec, f"path:{new_rel_path}")
-
-            # Track mapping for flake.lock updates
-            flake_path_replacements[old_rel_path] = new_rel_path
+        # Copy transitive inputs (only in flake.lock, resolved relative to parent)
+        # Only copy them - do NOT rewrite their paths in the top-level flake.lock
+        # because nix resolves transitive dep paths relative to the parent input,
+        # and the relative structure is preserved under local_packages/
+        for inp in transitive_inputs:
+            _copy_nix_input(inp)
 
         # Update flake.lock JSON for nodes that reference local path inputs
         if flake_path_replacements:


### PR DESCRIPTION
## Why are the changes needed?

When a direct nix flake path input (e.g. `minos2_rust`) itself depends on another path input (e.g. `rust-exautils`), that transitive dependency only appears in `flake.lock`, not in the top-level `flake.nix`. The builder previously only scanned `flake.nix` for `url = "path:..."` patterns, so transitive path deps were never copied into the Docker build context. This caused Docker/nix builds to fail with errors like:

```
error: path '/build/local_packages/rust/shared/exautils/flake.nix' does not exist
```

## What changes were proposed in this pull request?

1. **New function `discover_nix_flake_lock_path_inputs()`** in `image_spec.py`: Scans `flake.lock` JSON for all nodes with `"type": "path"` in their `locked` field, deduplicating against already-discovered direct inputs.

2. **Updated `_copy_local_packages_and_update_lock()`** in `default_builder.py`:
   - After discovering direct path inputs from `flake.nix`, also discovers transitive ones from `flake.lock`.
   - **Direct inputs**: copied into `local_packages/` AND paths rewritten in both `flake.nix` and `flake.lock`.
   - **Transitive inputs**: **only copied** into `local_packages/` — their paths in `flake.lock` are **not rewritten**. This is because nix resolves transitive dep paths relative to the parent input, not the root flake. Since both parent and child are copied preserving their git-root-relative structure under `local_packages/`, the relative paths between them remain correct.
   - Copy logic refactored into `_copy_nix_input()` helper.

3. **Updated `tag` hash computation** in `ImageSpec.tag`: Includes transitive path deps in the content hash so image tags change when transitive deps change.

## How was this patch tested?

Manually verified against the `exa_ml` flake which has the dependency chain `exa_ml → minos2_rust → rust-exautils` where `rust-exautils` is a transitive path dep that was previously missed.

Initial version rewrote transitive dep paths in the top-level `flake.lock`, which caused nix to resolve them relative to the parent input's new location, producing incorrect paths like:
```
/build/local_packages/python/minos2/minos2_rust/local_packages/rust/shared/exautils/flake.nix
```
Fixed by not rewriting transitive dep paths — the relative structure is preserved by the copy layout.

No unit tests added yet.

## Human review checklist

- [ ] **Transitive path resolution assumption**: The fix assumes nix resolves transitive dep paths relative to the parent input directory. Verify this holds for all nix flake path resolution scenarios (e.g. deeply nested transitive deps, absolute path inputs).
- [ ] **Silent skip of non-existent transitive deps**: `discover_nix_flake_lock_path_inputs` silently skips paths that don't exist on disk, while direct inputs in the builder raise `ValueError`. Is this asymmetry intentional/acceptable?
- [ ] **`already_discovered` set mutation**: The function mutates the caller's set as a side effect. Acceptable here but worth noting.
- [ ] **Relative structure preservation**: The fix relies on both direct and transitive inputs being copied under `local_packages/` preserving their original git-root-relative paths. If a transitive dep lives outside the git root, this could break.
- [ ] **Missing unit tests**: Both `discover_nix_flake_lock_path_inputs` and the copy-without-rewrite behavior for transitive deps should have test coverage.

## Check all the applicable boxes

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

---

Link to Devin run: https://app.devin.ai/sessions/ca581679e9554604bfc845afc7f50f97
Requested by: @sammiphone6