### PR TITLE
[image-spec]: fix transitive nix flake path inputs not copied to Docker build context

### DIFF
--- a/flytekit/image_spec/default_builder.py
+++ b/flytekit/image_spec/default_builder.py
@@ -22,6 +22,7 @@ from flytekit.image_spec.image_spec import (
     ImageSpecBuilder,
     _find_git_root,
     discover_nix_flake_path_inputs,
+    discover_transitive_nix_flake_path_inputs,
 )
 from flytekit.tools.ignore import DockerIgnore, GitIgnore, IgnoreGroup, StandardIgnore
 from flytekit.tools.script_mode import is_vendorable_repo, ls_files
@@ -429,6 +430,40 @@ def _copy_local_packages_and_update_lock(image_spec: ImageSpec, tmp_dir: Path):
 
             # Track mapping for flake.lock updates
             flake_path_replacements[old_rel_path] = new_rel_path
+
+        # Copy transitive path dependencies from flake.lock (dependencies of dependencies).
+        # Direct inputs are already handled above; transitive ones have a non-empty parent chain.
+        # Since local_packages/ mirrors the monorepo structure, relative paths between
+        # transitive deps are preserved automatically — no flake.lock path rewriting needed.
+        already_resolved = {inp.src_path.resolve() for inp in inputs}
+        transitive_inputs = discover_transitive_nix_flake_path_inputs(
+            lock_dir, flake_lock_content, already_resolved
+        )
+        for t_inp in transitive_inputs:
+            t_src = t_inp.src_path
+            t_git_root = _find_git_root(str(t_src))
+            if t_git_root is None:
+                continue
+
+            t_rel = os.path.relpath(path=str(t_src), start=str(t_git_root))
+            t_target = local_packages_dir / t_rel
+            t_target.parent.mkdir(parents=True, exist_ok=True)
+
+            if t_src.is_dir():
+                t_ignore = IgnoreGroup(str(t_src), [GitIgnore, DockerIgnore, StandardIgnore])
+                t_files, _ = ls_files(
+                    str(t_src),
+                    CopyFileDetection.ALL,
+                    deref_symlinks=False,
+                    ignore_group=t_ignore,
+                )
+                for t_file in t_files:
+                    t_file_rel = os.path.relpath(t_file, start=str(t_src))
+                    t_file_dst = t_target / t_file_rel
+                    t_file_dst.parent.mkdir(parents=True, exist_ok=True)
+                    shutil.copy2(t_file, t_file_dst)
+            else:
+                shutil.copy2(str(t_src), str(t_target))
 
         # Update flake.lock JSON for nodes that reference local path inputs
         if flake_path_replacements:

--- a/flytekit/image_spec/image_spec.py
+++ b/flytekit/image_spec/image_spec.py
@@ -82,6 +82,101 @@ def discover_nix_flake_path_inputs(
     return inputs
 
 
+def discover_transitive_nix_flake_path_inputs(
+    lock_dir: typing.Union[str, pathlib.Path],
+    flake_lock_content: str,
+    already_resolved: typing.Optional[typing.Set[pathlib.Path]] = None,
+) -> List[NixFlakePathInput]:
+    """Discover transitive Nix flake path inputs from flake.lock.
+
+    Direct path inputs (parent=[]) are handled by discover_nix_flake_path_inputs
+    via flake.nix parsing. This function finds transitive path inputs — those with
+    a non-empty parent chain in flake.lock — which are dependencies of dependencies.
+
+    Path resolution: each node's ``locked.path`` is relative to the directory of its
+    declaring parent (the last element in the ``parent`` chain). We walk the chain
+    recursively to compute the absolute source path.
+
+    Args:
+        lock_dir: Directory containing flake.lock (same as flake.nix location).
+        flake_lock_content: Contents of flake.lock as a string.
+        already_resolved: Set of already-resolved absolute paths to skip (from direct inputs).
+
+    Returns:
+        List of NixFlakePathInput entries for transitive path dependencies only.
+    """
+    import json as _json
+
+    lock_dir_path = pathlib.Path(lock_dir)
+    already_resolved = already_resolved or set()
+
+    try:
+        lock_obj = _json.loads(flake_lock_content)
+    except Exception:
+        return []
+
+    nodes = lock_obj.get("nodes", {})
+    abs_cache: typing.Dict[str, typing.Optional[pathlib.Path]] = {}
+
+    def _resolve(node_name: str) -> typing.Optional[pathlib.Path]:
+        if node_name in abs_cache:
+            return abs_cache[node_name]
+
+        node = nodes.get(node_name)
+        if not node:
+            abs_cache[node_name] = None
+            return None
+
+        locked = node.get("locked", {})
+        if locked.get("type") != "path":
+            abs_cache[node_name] = None
+            return None
+
+        rel_path = locked.get("path", "")
+        parent_chain = node.get("parent", [])
+
+        if not parent_chain:
+            result = (lock_dir_path / rel_path).resolve()
+        else:
+            declaring_parent = parent_chain[-1]
+            parent_abs = _resolve(declaring_parent)
+            if parent_abs is None:
+                abs_cache[node_name] = None
+                return None
+            result = (parent_abs / rel_path).resolve()
+
+        abs_cache[node_name] = result
+        return result
+
+    transitive: List[NixFlakePathInput] = []
+    for node_name, node in nodes.items():
+        if node_name == "root":
+            continue
+        locked = node.get("locked", {})
+        if locked.get("type") != "path":
+            continue
+        parent_chain = node.get("parent", [])
+        if not parent_chain:
+            continue
+
+        src_path = _resolve(node_name)
+        if src_path is None or not src_path.exists():
+            continue
+        if src_path in already_resolved:
+            continue
+
+        rel_path = locked.get("path", "")
+        transitive.append(
+            NixFlakePathInput(
+                full_spec=f"path:{rel_path}",
+                old_rel_path=rel_path,
+                src_path=src_path,
+            )
+        )
+
+    return transitive
+
+
 def _compute_directory_digest(dir_path: pathlib.Path) -> str:
     """Compute a stable digest for a directory mirroring builder copy logic (respects .gitignore/.dockerignore)."""
     # Imports here to avoid circular imports at module load time


### PR DESCRIPTION
## Why are the changes needed?

Training CI tests (e.g. `training-pretrain-aws-test`) fail with:
```
error: path '/build/local_packages/rust/shared/exautils/flake.nix' does not exist
```

The existing `discover_nix_flake_path_inputs()` only finds **direct** path inputs declared in `flake.nix` via regex. It does not discover **transitive** path dependencies recorded in `flake.lock` — i.e., dependencies of dependencies.

Concrete example in the `exa_ml` flake:
1. `exa_ml/flake.nix` → `minos2_rust` (direct, copied ✓)
2. `minos2_rust/flake.nix` → `rust-exautils` (transitive via flake.lock, **not copied** ✗)
3. `rust-exautils/flake.nix` → `rust-base` (transitive via flake.lock, **not copied** ✗)

When Nix evaluates the root flake inside the Docker build, it reads the root `flake.lock` which references these transitive paths — but the directories were never copied into `local_packages/`, so the build fails.

## What changes were proposed in this pull request?

**`flytekit/image_spec/image_spec.py`** — New function `discover_transitive_nix_flake_path_inputs()`:
- Parses `flake.lock` JSON to find all nodes with `locked.type == "path"` and a non-empty `parent` chain (transitive deps)
- Resolves each node's absolute source path by recursively walking the parent chain (`parent[-1]` = declaring parent; path is relative to that parent's directory)
- Uses a cache to avoid redundant resolution
- Skips nodes already handled as direct inputs (via `already_resolved` set)

**`flytekit/image_spec/default_builder.py`** — In `_copy_local_packages_and_update_lock()`:
- After copying direct flake path inputs, calls `discover_transitive_nix_flake_path_inputs()` and copies the discovered transitive deps into `local_packages/`
- No `flake.lock` path rewriting is needed for transitive deps because `local_packages/` mirrors the monorepo directory structure, preserving relative paths between packages

## How was this patch tested?

Verified with an inline integration test that simulates the `exa_ml` dependency chain (root → `minos2_rust` → `rust-exautils` → `rust-base`) and confirms both transitive deps are discovered with correct absolute paths.

No committed unit tests were added — the function is exercised only through CI's Nix image builds.

## Human review checklist

- [ ] **Verify `parent[-1]` interpretation**: The code assumes the last element of the `parent` chain in flake.lock v7 is the declaring parent whose directory the path is relative to. Confirm this matches Nix's flake.lock spec.
- [ ] **Silent skip on unresolvable transitive deps**: When `_find_git_root()` returns `None` for a transitive dep, it's silently skipped (`continue`). Direct inputs raise `ValueError` instead. Consider whether a warning/error would be more appropriate to surface issues early.
- [ ] **Large directory copies**: Transitive deps like `rust-base` could point to the entire `rust/` directory. Confirm that copying large subtrees with gitignore filtering doesn't cause excessive build context size/time.
- [ ] **Bare `except Exception`**: JSON parsing failure returns empty list silently. Could mask real issues if flake.lock is corrupted.

---

**Link to Devin Session**: https://app.devin.ai/sessions/46b404cede304b2b8ce0d143523914d8  
**Requested by**: @Vervious (benchan@exa.ai)