### PR TITLE
[flytekit]: Nix-based ImageSpec builder wrapping makePythonProject

### DIFF
--- a/flytekit/image_spec/__init__.py
+++ b/flytekit/image_spec/__init__.py
@@ -17,6 +17,8 @@ This module contains the ImageSpec class parameters and methods.
 
 from .default_builder import DefaultImageBuilder
 from .image_spec import ImageBuildEngine, ImageSpec
+from .nix_builder import NixImageSpecBuilder, nix_image_spec
 
 # Set this to a lower priority compared to `envd` to maintain backward compatibility
 ImageBuildEngine.register("default", DefaultImageBuilder(), priority=1)
+ImageBuildEngine.register("nix", NixImageSpecBuilder(), priority=0)

--- a/flytekit/image_spec/nix_builder.py
+++ b/flytekit/image_spec/nix_builder.py
@@ -1,0 +1,256 @@
+from __future__ import annotations
+
+import dataclasses
+import json
+import os
+import platform
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import ClassVar, Dict, List, Optional
+
+import click
+
+from flytekit.image_spec.default_builder import _copy_lock_files_into_context
+from flytekit.image_spec.image_spec import ImageSpec, ImageSpecBuilder
+
+_PYTHON_VERSION_TO_NIX: Dict[str, str] = {
+    "3.9": "python39",
+    "3.10": "python310",
+    "3.11": "python311",
+    "3.12": "python312",
+    "python39": "python39",
+    "python310": "python310",
+    "python311": "python311",
+    "python312": "python312",
+}
+
+_PLATFORM_TO_NIX_SYSTEM: Dict[str, str] = {
+    "linux/amd64": "x86_64-linux",
+    "linux/arm64": "aarch64-linux",
+}
+
+
+class NixImageSpecBuilder(ImageSpecBuilder):
+    """Build uv.lock-backed OCI images with Nix and nix2container.
+
+    Uses the project's own flake.nix when present, or generates one that
+    wraps makePythonProject.  Requires ``nix`` on PATH.
+    """
+
+    _SUPPORTED_IMAGE_SPEC_PARAMETERS: ClassVar[set] = {
+        "builder",
+        "entrypoint",
+        "env",
+        "id",
+        "install_project",
+        "name",
+        "nix",
+        "platform",
+        "python_version",
+        "registry",
+        "requirements",
+        "tag",
+        "tag_format",
+        # Fields with non-None defaults that are harmless to ignore.
+        "use_depot",
+        "uv_export_args",
+        "vendor_local",
+    }
+
+    def build_image(self, image_spec: ImageSpec) -> Optional[str]:
+        return self._build_image(
+            image_spec,
+            push=os.getenv("FLYTE_PUSH_IMAGE_SPEC", "True").lower() in ("true", "1"),
+        )
+
+    def _build_image(self, image_spec: ImageSpec, *, push: bool = True) -> str:
+        self._validate(image_spec)
+
+        if not shutil.which("nix"):
+            raise RuntimeError(
+                "Nix is not installed or not in PATH. "
+                "Please install Nix (https://nixos.org/download)"
+            )
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            lock_dir = Path(image_spec.requirements).resolve().parent
+            context_spec = dataclasses.replace(
+                image_spec,
+                nix=(lock_dir / "flake.nix").exists(),
+            )
+
+            _copy_lock_files_into_context(context_spec, "uv.lock", tmp_path)
+            _ensure_flake(tmp_path, image_spec)
+
+            command = _build_command(image_spec, tmp_path, push=push)
+            log_command = _redact_creds(command)
+            click.secho(f"Run command: {' '.join(log_command)} ", fg="blue")
+
+            result = subprocess.run(command)
+            if result.returncode != 0:
+                raise RuntimeError(
+                    f"Build command failed with exit code {result.returncode}: "
+                    f"{' '.join(log_command)}"
+                )
+
+            return image_spec.image_name()
+
+    def _validate(self, image_spec: ImageSpec) -> None:
+        if not image_spec.requirements or Path(image_spec.requirements).name != "uv.lock":
+            raise ValueError("NixImageSpecBuilder only supports uv.lock requirements.")
+
+        unsupported = [
+            name
+            for name, value in vars(image_spec).items()
+            if value is not None
+            and name not in self._SUPPORTED_IMAGE_SPEC_PARAMETERS
+            and not name.startswith("_")
+        ]
+        if unsupported:
+            raise ValueError(
+                f"NixImageSpecBuilder does not support: {', '.join(sorted(unsupported))}"
+            )
+
+        if image_spec.python_version and image_spec.python_version not in _PYTHON_VERSION_TO_NIX:
+            raise ValueError(
+                f"Unsupported python_version {image_spec.python_version!r}. "
+                f"Supported: {', '.join(sorted(_PYTHON_VERSION_TO_NIX))}"
+            )
+
+        if image_spec.platform not in _PLATFORM_TO_NIX_SYSTEM:
+            raise ValueError(
+                f"Unsupported platform {image_spec.platform!r}. "
+                f"Supported: {', '.join(sorted(_PLATFORM_TO_NIX_SYSTEM))}"
+            )
+
+def _build_command(image_spec: ImageSpec, tmp_path: Path, *, push: bool) -> List[str]:
+    nix_system = _PLATFORM_TO_NIX_SYSTEM[image_spec.platform]
+    local_system = _local_nix_system()
+    is_cross_build = nix_system != local_system
+
+    if push and image_spec.registry:
+        ecr_token = subprocess.run(
+            ["aws", "ecr", "get-login-password", "--region", "us-west-2"],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+
+        if is_cross_build:
+            docker_attr = f"packages.{local_system}.docker-{nix_system}.copyTo"
+            click.secho(f"Cross-build: {nix_system} image via {local_system} n2c", fg="yellow")
+        else:
+            docker_attr = f"packages.{nix_system}.docker.copyTo"
+
+        return [
+            "nix", "run",
+            f"path:{tmp_path}#{docker_attr}", "--",
+            f"docker://{image_spec.image_name()}",
+            "--dest-creds", f"AWS:{ecr_token}",
+            "--image-parallel-copies", "32",
+        ]
+
+    return ["nix", "build", f"path:{tmp_path}#packages.{nix_system}.docker"]
+
+
+def _ensure_flake(tmp_path: Path, image_spec: ImageSpec) -> None:
+    if (tmp_path / "flake.nix").exists():
+        return
+    (tmp_path / "flake.nix").write_text(_render_flake(image_spec))
+
+
+def _render_flake(image_spec: ImageSpec) -> str:
+    python_version = _PYTHON_VERSION_TO_NIX.get(image_spec.python_version or "3.10", "python310")
+    docker_image_spec = {
+        "name": image_spec.name,
+        "tag": image_spec.image_name().rsplit(":", 1)[1],
+        "cmd": image_spec.entrypoint or ["pyflyte-execute"],
+        "extraEnv": image_spec.env or {},
+    }
+    flake_path = os.getenv("FLYTEKIT_NIX_PYTHON_FLAKE", "")
+    if not flake_path:
+        raise RuntimeError(
+            "Set FLYTEKIT_NIX_PYTHON_FLAKE to the path of the makePythonProject flake "
+            "(e.g. /path/to/monorepo/flakes/python) when using the nix builder without "
+            "an existing flake.nix in the project directory."
+        )
+
+    return (
+        "{\n"
+        '  description = "Generated Flyte ImageSpec nix image";\n'
+        "\n"
+        "  inputs = {\n"
+        f'    python-flake.url = "path:{flake_path}";\n'
+        "  };\n"
+        "\n"
+        "  outputs =\n"
+        "    { python-flake, ... }:\n"
+        "    python-flake.inputs.flake-utils.lib.eachDefaultSystem (\n"
+        "      system:\n"
+        "      let\n"
+        "        project = python-flake.lib.makePythonProject {\n"
+        "          inherit system;\n"
+        "          workspaceRoot = ./.;\n"
+        f'          pythonVersion = "{python_version}";\n'
+        f"          dockerImageSpec = {_to_nix(docker_image_spec)};\n"
+        "        };\n"
+        "      in\n"
+        "      { inherit (project) packages devShells; }\n"
+        "    );\n"
+        "}\n"
+    )
+
+
+def nix_image_spec(requirements: str, **kwargs: object) -> ImageSpec:
+    return ImageSpec(builder="nix", requirements=requirements, nix=True, **kwargs)
+
+
+def _local_nix_system() -> str:
+    os_suffix = "darwin" if platform.system() == "Darwin" else "linux"
+    machine_map = {
+        "aarch64": f"aarch64-{os_suffix}",
+        "arm64": f"aarch64-{os_suffix}",
+        "x86_64": f"x86_64-{os_suffix}",
+    }
+    return machine_map.get(platform.machine(), f"x86_64-{os_suffix}")
+
+
+def _to_nix(value: object, *, indent: int = 10) -> str:
+    space = " " * indent
+    child_space = " " * (indent + 2)
+
+    if isinstance(value, dict):
+        if not value:
+            return "{ }"
+        lines = ["{"]
+        for k, v in value.items():
+            lines.append(f"{child_space}{k} = {_to_nix(v, indent=indent + 2)};")
+        lines.append(f"{space}}}")
+        return "\n".join(lines)
+
+    if isinstance(value, list):
+        if not value:
+            return "[ ]"
+        return "[ " + " ".join(_to_nix(item, indent=indent) for item in value) + " ]"
+
+    if isinstance(value, str):
+        return json.dumps(value)
+
+    if isinstance(value, bool):
+        return "true" if value else "false"
+
+    if value is None:
+        return "null"
+
+    return json.dumps(value)
+
+
+def _redact_creds(command: List[str]) -> List[str]:
+    redacted = list(command)
+    for i, arg in enumerate(redacted):
+        if arg == "--dest-creds" and i + 1 < len(redacted):
+            redacted[i + 1] = "[REDACTED]"
+    return redacted

--- a/tests/flytekit/unit/core/image_spec/test_nix_builder.py
+++ b/tests/flytekit/unit/core/image_spec/test_nix_builder.py
@@ -1,0 +1,292 @@
+from __future__ import annotations
+
+import subprocess
+import tempfile
+from pathlib import Path
+from unittest import mock
+
+import pytest
+import toml
+
+from flytekit.image_spec.image_spec import ImageSpec
+from flytekit.image_spec.nix_builder import NixImageSpecBuilder, nix_image_spec
+
+
+class PreservedTemporaryDirectory:
+    def __init__(self, path: Path):
+        self.path = path
+
+    def __enter__(self) -> str:
+        self.path.mkdir(parents=True, exist_ok=True)
+        return str(self.path)
+
+    def __exit__(self, exc_type, exc_value, traceback) -> None:
+        return None
+
+
+def _create_uv_project(tmp_path: Path, *, with_flake: bool = False) -> Path:
+    pyproject = {
+        "project": {
+            "name": "test-project",
+            "version": "0.1.0",
+            "dependencies": ["requests==2.31.0"],
+        },
+        "build-system": {
+            "requires": ["hatchling"],
+            "build-backend": "hatchling.build",
+        },
+    }
+    with open(tmp_path / "pyproject.toml", "w") as f:
+        toml.dump(pyproject, f)
+
+    lock_data = {
+        "version": 1,
+        "requires-python": ">=3.10",
+        "package": [
+            {
+                "name": "requests",
+                "version": "2.31.0",
+                "source": {"registry": "https://pypi.org/simple"},
+            },
+            {
+                "name": "test-project",
+                "version": "0.1.0",
+                "source": {"editable": "."},
+                "dependencies": [{"name": "requests"}],
+                "metadata": {
+                    "requires-dist": [
+                        {"name": "requests", "specifier": "==2.31.0"},
+                    ],
+                },
+            },
+        ],
+    }
+    lock_path = tmp_path / "uv.lock"
+    with open(lock_path, "w") as f:
+        toml.dump(lock_data, f)
+
+    if with_flake:
+        (tmp_path / "flake.nix").write_text('{ outputs = { ... }: {}; }')
+        (tmp_path / "flake.lock").write_text("{}")
+
+    subprocess.run(["git", "init", str(tmp_path)], capture_output=True, check=True)
+    subprocess.run(["git", "-C", str(tmp_path), "add", "."], capture_output=True, check=True)
+
+    return lock_path
+
+
+class TestNixImageSpecBuilderValidation:
+    def test_rejects_non_uv_lock(self):
+        spec = ImageSpec(name="test", requirements="requirements.txt")
+        with pytest.raises(ValueError, match="only supports uv.lock"):
+            NixImageSpecBuilder().build_image(spec)
+
+    def test_rejects_missing_requirements(self):
+        spec = ImageSpec(name="test")
+        with pytest.raises(ValueError, match="only supports uv.lock"):
+            NixImageSpecBuilder().build_image(spec)
+
+    def test_rejects_unsupported_parameters(self):
+        with tempfile.TemporaryDirectory() as d:
+            lock_path = _create_uv_project(Path(d))
+            spec = ImageSpec(
+                name="test",
+                requirements=str(lock_path),
+                packages=["numpy"],
+                apt_packages=["git"],
+            )
+            with pytest.raises(ValueError, match="does not support"):
+                NixImageSpecBuilder().build_image(spec)
+
+    def test_rejects_unsupported_python_version(self):
+        with tempfile.TemporaryDirectory() as d:
+            lock_path = _create_uv_project(Path(d))
+            spec = ImageSpec(
+                name="test",
+                requirements=str(lock_path),
+                python_version="3.8",
+            )
+            with pytest.raises(ValueError, match="Unsupported python_version"):
+                NixImageSpecBuilder().build_image(spec)
+
+    def test_rejects_unsupported_platform(self):
+        with tempfile.TemporaryDirectory() as d:
+            lock_path = _create_uv_project(Path(d))
+            spec = ImageSpec(
+                name="test",
+                requirements=str(lock_path),
+                platform="linux/s390x",
+            )
+            with pytest.raises(ValueError, match="Unsupported platform"):
+                NixImageSpecBuilder().build_image(spec)
+
+    @mock.patch("flytekit.image_spec.nix_builder.subprocess")
+    @mock.patch("flytekit.image_spec.default_builder.subprocess.run")
+    @mock.patch("flytekit.image_spec.nix_builder.shutil.which", return_value="/nix/bin/nix")
+    def test_accepts_all_supported_python_versions(self, _mock_which, _mock_export, mock_subprocess):
+        mock_subprocess.run.return_value = mock.Mock(returncode=0)
+
+        for version in ("3.9", "3.10", "3.11", "3.12"):
+            with tempfile.TemporaryDirectory() as d:
+                lock_path = _create_uv_project(Path(d), with_flake=True)
+                spec = ImageSpec(
+                    name="test",
+                    requirements=str(lock_path),
+                    python_version=version,
+                    nix=True,
+                )
+                assert NixImageSpecBuilder().build_image(spec) == spec.image_name()
+
+
+class TestBuildImage:
+    @mock.patch.dict("os.environ", {"FLYTE_PUSH_IMAGE_SPEC": "false"})
+    @mock.patch("flytekit.image_spec.nix_builder.subprocess")
+    @mock.patch("flytekit.image_spec.default_builder.subprocess.run")
+    @mock.patch("flytekit.image_spec.nix_builder.shutil.which", return_value="/nix/bin/nix")
+    def test_build_local_no_push(self, _mock_which, _mock_export, mock_subprocess):
+        mock_subprocess.run.return_value = mock.Mock(returncode=0)
+
+        with tempfile.TemporaryDirectory() as d:
+            lock_path = _create_uv_project(Path(d), with_flake=True)
+            spec = ImageSpec(
+                name="test",
+                requirements=str(lock_path),
+                platform="linux/amd64",
+                nix=True,
+            )
+            result = NixImageSpecBuilder().build_image(spec)
+
+        assert result == spec.image_name()
+        cmd = mock_subprocess.run.call_args[0][0]
+        assert cmd[0] == "nix"
+        assert cmd[1] == "build"
+        assert "packages.x86_64-linux.docker" in cmd[2]
+
+    @mock.patch.dict("os.environ", {"FLYTE_PUSH_IMAGE_SPEC": "true"})
+    @mock.patch("flytekit.image_spec.nix_builder.subprocess")
+    @mock.patch("flytekit.image_spec.default_builder.subprocess.run")
+    @mock.patch("flytekit.image_spec.nix_builder.shutil.which", return_value="/nix/bin/nix")
+    def test_build_push_to_ecr(self, _mock_which, _mock_export, mock_subprocess):
+        mock_ecr_result = mock.Mock(returncode=0, stdout="ecr-token-value\n")
+        mock_build_result = mock.Mock(returncode=0)
+        mock_subprocess.run.side_effect = [mock_ecr_result, mock_build_result]
+
+        with tempfile.TemporaryDirectory() as d:
+            lock_path = _create_uv_project(Path(d), with_flake=True)
+            spec = ImageSpec(
+                name="test",
+                requirements=str(lock_path),
+                registry="472386928882.dkr.ecr.us-west-2.amazonaws.com/exa",
+                platform="linux/amd64",
+                nix=True,
+            )
+            result = NixImageSpecBuilder().build_image(spec)
+
+        assert result == spec.image_name()
+        ecr_call, build_call = mock_subprocess.run.call_args_list
+        assert "get-login-password" in ecr_call[0][0]
+        cmd = build_call[0][0]
+        assert cmd[0] == "nix"
+        assert cmd[1] == "run"
+        assert "copyTo" in cmd[2]
+        assert f"docker://{spec.image_name()}" in cmd
+
+    @mock.patch("flytekit.image_spec.nix_builder.shutil.which", return_value=None)
+    def test_raises_when_nix_missing(self, _mock_which):
+        with tempfile.TemporaryDirectory() as d:
+            lock_path = _create_uv_project(Path(d))
+            spec = ImageSpec(
+                name="test",
+                requirements=str(lock_path),
+                nix=True,
+            )
+            with pytest.raises(RuntimeError, match="Nix is not installed"):
+                NixImageSpecBuilder().build_image(spec)
+
+    @mock.patch.dict("os.environ", {"FLYTE_PUSH_IMAGE_SPEC": "false"})
+    @mock.patch("flytekit.image_spec.nix_builder.subprocess")
+    @mock.patch("flytekit.image_spec.default_builder.subprocess.run")
+    @mock.patch("flytekit.image_spec.nix_builder.shutil.which", return_value="/nix/bin/nix")
+    def test_raises_on_build_failure(self, _mock_which, _mock_export, mock_subprocess):
+        mock_subprocess.run.return_value = mock.Mock(returncode=1)
+
+        with tempfile.TemporaryDirectory() as d:
+            lock_path = _create_uv_project(Path(d), with_flake=True)
+            spec = ImageSpec(
+                name="test",
+                requirements=str(lock_path),
+                nix=True,
+            )
+            with pytest.raises(RuntimeError, match="Build command failed"):
+                NixImageSpecBuilder().build_image(spec)
+
+    @mock.patch.dict(
+        "os.environ",
+        {
+            "FLYTE_PUSH_IMAGE_SPEC": "false",
+            "FLYTEKIT_NIX_PYTHON_FLAKE": "/nix/flakes/python",
+        },
+    )
+    @mock.patch("flytekit.image_spec.nix_builder.subprocess")
+    @mock.patch("flytekit.image_spec.default_builder.subprocess.run")
+    @mock.patch("flytekit.image_spec.nix_builder.shutil.which", return_value="/nix/bin/nix")
+    def test_generates_flake_when_project_has_none(self, _mock_which, _mock_export, mock_subprocess):
+        mock_subprocess.run.return_value = mock.Mock(returncode=0)
+
+        with tempfile.TemporaryDirectory() as project_dir, tempfile.TemporaryDirectory() as build_dir:
+            lock_path = _create_uv_project(Path(project_dir))
+            spec = ImageSpec(
+                name="my-image",
+                requirements=str(lock_path),
+                python_version="3.12",
+                env={"FOO": "bar"},
+                entrypoint=["python", "-m", "myapp"],
+                nix=True,
+            )
+            preserved_tmp = PreservedTemporaryDirectory(Path(build_dir))
+            with mock.patch("flytekit.image_spec.nix_builder.tempfile.TemporaryDirectory", return_value=preserved_tmp):
+                assert NixImageSpecBuilder().build_image(spec) == spec.image_name()
+
+            flake = (Path(build_dir) / "flake.nix").read_text()
+
+        assert "makePythonProject" in flake
+        assert 'pythonVersion = "python312"' in flake
+        assert 'FOO = "bar"' in flake
+        assert '"python"' in flake
+        assert '"myapp"' in flake
+        assert 'python-flake.url = "path:/nix/flakes/python"' in flake
+
+    @mock.patch.dict("os.environ", {"FLYTE_PUSH_IMAGE_SPEC": "false"}, clear=True)
+    @mock.patch("flytekit.image_spec.nix_builder.subprocess")
+    @mock.patch("flytekit.image_spec.default_builder.subprocess.run")
+    @mock.patch("flytekit.image_spec.nix_builder.shutil.which", return_value="/nix/bin/nix")
+    def test_requires_python_flake_env_when_project_has_no_flake(self, _mock_which, _mock_export, mock_subprocess):
+        mock_subprocess.run.return_value = mock.Mock(returncode=0)
+
+        with tempfile.TemporaryDirectory() as d:
+            lock_path = _create_uv_project(Path(d))
+            spec = ImageSpec(
+                name="test",
+                requirements=str(lock_path),
+                nix=True,
+            )
+            with pytest.raises(RuntimeError, match="FLYTEKIT_NIX_PYTHON_FLAKE"):
+                NixImageSpecBuilder().build_image(spec)
+
+
+class TestNixImageSpecFactory:
+    def test_sets_builder_and_nix(self):
+        spec = nix_image_spec("uv.lock", name="test")
+        assert spec.builder == "nix"
+        assert spec.nix is True
+        assert spec.requirements == "uv.lock"
+
+    def test_passes_kwargs(self):
+        spec = nix_image_spec(
+            "uv.lock",
+            name="img",
+            registry="example.com/repo",
+            platform="linux/arm64",
+        )
+        assert spec.registry == "example.com/repo"
+        assert spec.platform == "linux/arm64"


### PR DESCRIPTION
## Why are the changes needed?

Building Flyte task container images currently requires Docker or depot. Projects that already use Nix and `makePythonProject` (via `uv2nix` + `nix2container`) have no way to leverage that infrastructure through Flyte's `ImageSpec` abstraction — they must maintain a parallel build path.

This PR adds a `NixImageSpecBuilder` so that any project with a `uv.lock` can build OCI images through Nix, using the same `ImageSpec` interface that Flyte tasks already consume.

## What changes were proposed in this pull request?

**New file: `flytekit/image_spec/nix_builder.py`**

- `NixImageSpecBuilder` — an `ImageSpecBuilder` subclass that:
  - Validates the `ImageSpec` only contains parameters compatible with a Nix build (rejects packages, apt_packages, conda, cuda, etc.)
  - Reuses `_copy_lock_files_into_context` from `default_builder` to handle local-package rewriting
  - If the project already has a `flake.nix`, uses it as-is
  - If not, generates a minimal `flake.nix` that wraps `makePythonProject` (configured via `FLYTEKIT_NIX_PYTHON_FLAKE` env var)
  - Calls `nix build` (local) or `nix run … copyTo` (push to ECR) with cross-compilation support
  - Supports Python 3.9–3.12 and linux/amd64 + linux/arm64

- `nix_image_spec(requirements, **kwargs)` — convenience factory that returns an `ImageSpec` pre-configured with `builder="nix"` and `nix=True`

**Modified: `flytekit/image_spec/__init__.py`**

- Registers the nix builder at priority 0 (lower than default's priority 1) so it's only used when explicitly requested via `builder="nix"`

**Usage:**

```python
from flytekit.image_spec import nix_image_spec

image = nix_image_spec(
    "uv.lock",
    name="my-service",
    python_version="3.12",
    registry="472386928882.dkr.ecr.us-west-2.amazonaws.com/exa",
)

@task(container_image=image)
def my_task(): ...
```

## How was this patch tested?

Unit tests in `tests/flytekit/unit/core/image_spec/test_nix_builder.py` (14 tests):

- Validation: rejects non-uv.lock requirements, unsupported parameters, bad python versions, bad platforms
- Build: mocked `nix build` for local builds, mocked `nix run … copyTo` for ECR push, verifies correct command construction
- Flake generation: verifies generated `flake.nix` contains correct `makePythonProject` call, python version, env vars, entrypoint
- Error handling: missing nix binary, build failures, missing `FLYTEKIT_NIX_PYTHON_FLAKE` env var
- Factory: `nix_image_spec` sets correct defaults

```
14 passed in 0.20s
```

## Check all the applicable boxes

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [ ] All commits are signed-off.

Link to Devin session: https://app.devin.ai/sessions/ccc5697639074693932b0b7aed586a19
Requested by: @Carlos-Marques