### PR TITLE
fix(image-spec): set NIX_SSL_CERT_FILE so nix can verify TLS in Docker builds

### DIFF
--- a/flytekit/image_spec/default_builder.py
+++ b/flytekit/image_spec/default_builder.py
@@ -182,6 +182,7 @@ RUN --mount=type=cache,target=/nix,id=nix-determinate \
         --extra-conf "max-substitution-jobs = 256" \
         --extra-conf "http-connections = 256" \
         --extra-conf "download-buffer-size = 1073741824" \
+        --extra-conf "ssl-cert-file = /etc/ssl/certs/ca-certificates.crt" \
         --init none \
         --no-confirm
 
@@ -189,10 +190,14 @@ RUN --mount=type=cache,target=/nix,id=nix-determinate \
 WORKDIR /build
 
 # Build with cache mount - reuses the same cache across builds
+# NIX_SSL_CERT_FILE tells the nix daemon's fetcher where to find CA
+# certificates so fetchurl/FOD downloads can verify TLS.  The
+# ca-certificates package (installed above via apt) provides the bundle.
 RUN --mount=type=bind,source=.,target=/build/ \
     --mount=type=cache,target=/nix,id=nix-determinate \
     --mount=type=cache,target=/root/.cache/nix,id=nix-git-cache \
     --mount=type=cache,target=/var/lib/containers/cache,id=container-cache \
+    export NIX_SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt && \
     . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh && \
     nix run .#docker.copyTo -- docker://$IMAGE_NAME --dest-creds "AWS:$ECR_TOKEN" \
     --image-parallel-copies 32 \


### PR DESCRIPTION
## Why are the changes needed?

When building Docker images with `nix=True` on depot remote builders, the nix daemon inside the Docker build container cannot verify SSL certificates when downloading fixed-output derivations (e.g., crate tarballs via `importCargoLock`). This causes `minos2_rust` and other Rust crate builds to fail:

```
trying https://crates.io/api/v1/crates/async-compression/0.4.34/download
curl: (22) SSL certificate OpenSSL verify result: unable to get local issuer certificate (20)
error: cannot download crate-async-compression-0.4.34.tar.gz from any mirror
error: Cannot build '/nix/store/...-minos2_rust.drv'
```

Although `ca-certificates` is installed via apt in the `NIX_DOCKER_FILE_TEMPLATE`, nix does not automatically discover system CA bundles — it needs explicit configuration.

## What changes were proposed in this pull request?

Two additions to `NIX_DOCKER_FILE_TEMPLATE`:

1. **`--extra-conf "ssl-cert-file = /etc/ssl/certs/ca-certificates.crt"`** during nix install — configures the nix daemon to permanently know where CA certificates live.
2. **`export NIX_SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt`** before sourcing `nix-daemon.sh` — ensures the nix client also picks up the cert bundle for binary cache / substituter access.

Both point to the CA bundle provided by the `ca-certificates` apt package already installed earlier in the Dockerfile.

## How was this patch tested?

Verified that:
- The `ca-certificates` apt package installs `/etc/ssl/certs/ca-certificates.crt` on Ubuntu 24.04
- The nix daemon respects both `ssl-cert-file` in nix.conf and `NIX_SSL_CERT_FILE` env var for TLS verification
- The change is backwards-compatible (setting the cert path when certs already work is a no-op)

Full validation requires a depot build of exa_ml with minos2_rust — the fix targets that specific failure path.

## Check all the applicable boxes

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

Link to Devin session: https://app.devin.ai/sessions/ab8a3bee55534c6cbb2d23f03da11f5f
Requested by: @Feel-ix-343