### PR TITLE
Add AWS STS auth mode and static gRPC metadata for Admin

### DIFF
--- a/flytekit/clients/auth/authenticator.py
+++ b/flytekit/clients/auth/authenticator.py
@@ -191,6 +191,59 @@ class CommandAuthenticator(Authenticator):
         self._creds = Credentials(output.stdout.strip())
 
 
+class STSAuthenticator(Authenticator):
+    """Authenticates with an AWS STS presigned-URL bearer token.
+
+    Used against Flyte deployments whose Admin proxy validates an AWS identity
+    (via ``sts:GetCallerIdentity``) instead of an OAuth2 id-token. A fresh token
+    is minted for every gRPC call because the presigned URL is only valid for a
+    short window; minting is local SigV4 signing (no network), and the resolved
+    AWS credentials are cached on the instance to avoid repeated credential
+    lookups. On an authentication failure the cache is cleared so rotated
+    credentials are picked up.
+    """
+
+    def __init__(
+        self,
+        endpoint: str,
+        header_key: typing.Optional[str] = None,
+        expires_in: typing.Optional[int] = None,
+        region: typing.Optional[str] = None,
+        verify: typing.Optional[typing.Union[bool, str]] = None,
+    ):
+        from .aws_sts import DEFAULT_EXPIRES_IN_SECONDS, DEFAULT_STS_REGION
+
+        super().__init__(endpoint, header_key or "authorization", verify=verify)
+        self._expires_in = expires_in or DEFAULT_EXPIRES_IN_SECONDS
+        self._region = region or DEFAULT_STS_REGION
+        self._aws_credentials: typing.Optional[typing.Tuple[str, str, typing.Optional[str]]] = None
+
+    def _mint_token(self) -> str:
+        from .aws_sts import create_sts_token, resolve_aws_credentials
+
+        if self._aws_credentials is None:
+            self._aws_credentials = resolve_aws_credentials()
+        access_key, secret_key, session_token = self._aws_credentials
+        return create_sts_token(
+            access_key,
+            secret_key,
+            session_token,
+            expires_in=self._expires_in,
+            region=self._region,
+        )
+
+    def refresh_credentials(self):
+        # Drop cached AWS credentials so rotated/expired credentials (SSO, IMDS,
+        # assumed-role) are re-resolved on the retry that follows.
+        self._aws_credentials = None
+        self._set_credentials(Credentials(self._mint_token()))
+
+    def fetch_grpc_call_auth_metadata(self) -> typing.Optional[typing.Tuple[str, str]]:
+        # Always mint a fresh presigned token: the URL is short-lived, so caching
+        # a single token across a long-running command would let it expire.
+        return self._header_key, f"Bearer {self._mint_token()}"
+
+
 class ClientCredentialsAuthenticator(Authenticator):
     """
     This Authenticator uses ClientId and ClientSecret to authenticate

--- a/flytekit/clients/auth/aws_sts.py
+++ b/flytekit/clients/auth/aws_sts.py
@@ -1,0 +1,216 @@
+"""AWS STS presigned-URL bearer tokens for Flyte Admin authentication.
+
+Some Flyte deployments front Admin with a proxy that authenticates callers by
+validating an AWS identity instead of an OAuth2 id-token. The bearer token is a
+base64url-encoded, presigned ``sts:GetCallerIdentity`` URL: the proxy decodes
+it, replays the ``GetCallerIdentity`` call against AWS STS, and trusts the
+returned principal ARN as the caller's identity.
+
+This module mints that token using only the standard library so flytekit gains
+no new dependency. It mirrors the scheme used by Exa's ``overseer`` CLI so the
+two clients produce tokens the same proxy accepts.
+"""
+
+import configparser
+import hashlib
+import hmac
+import json
+import os
+import subprocess
+import urllib.parse
+import urllib.request
+from base64 import urlsafe_b64encode
+from datetime import datetime, timezone
+
+#: STS endpoint the presigned ``GetCallerIdentity`` URL targets. The global
+#: endpoint is used so the proxy can replay it from any region.
+DEFAULT_STS_HOST = "sts.amazonaws.com"
+DEFAULT_STS_REGION = "us-east-1"
+_STS_SERVICE = "sts"
+
+#: Default validity window for a presigned URL. Tokens are minted fresh per
+#: request, so this only needs to cover clock skew plus request latency.
+DEFAULT_EXPIRES_IN_SECONDS = 60
+
+_IMDS_BASE = "http://169.254.169.254"
+_IMDS_TIMEOUT_SECONDS = 2
+
+
+class STSCredentialsError(Exception):
+    """Raised when no AWS credentials can be resolved for STS auth."""
+
+
+def _hmac_sha256(key: bytes, message: str) -> bytes:
+    return hmac.new(key, message.encode("utf-8"), hashlib.sha256).digest()
+
+
+def _sha256_hex(data: str) -> str:
+    return hashlib.sha256(data.encode("utf-8")).hexdigest()
+
+
+def _credentials_from_env() -> "tuple[str, str, str | None] | None":
+    access_key = os.environ.get("AWS_ACCESS_KEY_ID")
+    secret_key = os.environ.get("AWS_SECRET_ACCESS_KEY")
+    if access_key and secret_key:
+        return access_key, secret_key, os.environ.get("AWS_SESSION_TOKEN")
+    return None
+
+
+def _credentials_from_shared_file(profile: str) -> "tuple[str, str, str | None] | None":
+    creds_path = os.path.expanduser(os.environ.get("AWS_SHARED_CREDENTIALS_FILE", "~/.aws/credentials"))
+    if not os.path.exists(creds_path):
+        return None
+    ini = configparser.ConfigParser()
+    ini.read(creds_path)
+    if not ini.has_section(profile):
+        return None
+    access_key = ini.get(profile, "aws_access_key_id", fallback=None)
+    secret_key = ini.get(profile, "aws_secret_access_key", fallback=None)
+    if access_key and secret_key:
+        return access_key, secret_key, ini.get(profile, "aws_session_token", fallback=None)
+    return None
+
+
+def _credentials_from_export(profile: str) -> "tuple[str, str, str | None] | None":
+    """Resolve SSO / ``credential_process`` profiles via the AWS CLI.
+
+    These credential sources are not stored as plain keys, so we shell out to
+    ``aws configure export-credentials`` (the supported way to materialize
+    them) only when the profile actually declares such a source.
+    """
+    config_path = os.path.expanduser(os.environ.get("AWS_CONFIG_FILE", "~/.aws/config"))
+    config_ini = configparser.ConfigParser()
+    if os.path.exists(config_path):
+        config_ini.read(config_path)
+    section = "default" if profile == "default" else f"profile {profile}"
+    needs_export = any(
+        config_ini.has_option(section, opt) for opt in ("sso_start_url", "sso_session", "credential_process")
+    )
+    if not needs_export:
+        return None
+    try:
+        result = subprocess.run(
+            ["aws", "configure", "export-credentials", "--profile", profile, "--format", "env"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    exported: "dict[str, str]" = {}
+    for line in result.stdout.strip().splitlines():
+        line = line.removeprefix("export ").strip()
+        if "=" in line:
+            key, value = line.split("=", 1)
+            exported[key.strip()] = value.strip()
+    access_key = exported.get("AWS_ACCESS_KEY_ID")
+    secret_key = exported.get("AWS_SECRET_ACCESS_KEY")
+    if access_key and secret_key:
+        return access_key, secret_key, exported.get("AWS_SESSION_TOKEN")
+    return None
+
+
+def _credentials_from_imds() -> "tuple[str, str, str | None] | None":
+    """Resolve the instance/pod role credentials via IMDSv2."""
+    try:
+        token_req = urllib.request.Request(
+            f"{_IMDS_BASE}/latest/api/token",
+            method="PUT",
+            headers={"X-aws-ec2-metadata-token-ttl-seconds": "21600"},
+        )
+        imds_token = urllib.request.urlopen(token_req, timeout=_IMDS_TIMEOUT_SECONDS).read().decode()
+        headers = {"X-aws-ec2-metadata-token": imds_token}
+        role_req = urllib.request.Request(
+            f"{_IMDS_BASE}/latest/meta-data/iam/security-credentials/",
+            headers=headers,
+        )
+        role_name = urllib.request.urlopen(role_req, timeout=_IMDS_TIMEOUT_SECONDS).read().decode().strip()
+        creds_req = urllib.request.Request(
+            f"{_IMDS_BASE}/latest/meta-data/iam/security-credentials/{role_name}",
+            headers=headers,
+        )
+        creds = json.loads(urllib.request.urlopen(creds_req, timeout=_IMDS_TIMEOUT_SECONDS).read())
+    except Exception:
+        return None
+    access_key = creds.get("AccessKeyId")
+    secret_key = creds.get("SecretAccessKey")
+    if access_key and secret_key:
+        return access_key, secret_key, creds.get("Token")
+    return None
+
+
+def resolve_aws_credentials() -> "tuple[str, str, str | None]":
+    """Resolve AWS credentials: env vars → config file → SSO export → IMDS.
+
+    Returns an ``(access_key, secret_key, session_token)`` triple, where the
+    session token is ``None`` for long-lived IAM-user credentials. Raises
+    :class:`STSCredentialsError` when no source yields credentials.
+    """
+    profile = os.environ.get("AWS_PROFILE", "default")
+    for source in (
+        _credentials_from_env,
+        lambda: _credentials_from_shared_file(profile),
+        lambda: _credentials_from_export(profile),
+        _credentials_from_imds,
+    ):
+        creds = source()
+        if creds is not None:
+            return creds
+    raise STSCredentialsError(
+        "no AWS credentials found for STS auth (checked env vars, AWS config/credentials, and IMDS)"
+    )
+
+
+def create_sts_token(
+    access_key: str,
+    secret_key: str,
+    session_token: "str | None" = None,
+    *,
+    expires_in: int = DEFAULT_EXPIRES_IN_SECONDS,
+    region: str = DEFAULT_STS_REGION,
+    host: str = DEFAULT_STS_HOST,
+) -> str:
+    """Build the base64url-encoded presigned ``GetCallerIdentity`` URL.
+
+    The result is the value an STS auth proxy expects as the bearer token. The
+    URL is signed with SigV4 over the ``host`` header only, matching the
+    minimal canonical request the proxy replays.
+    """
+    now = datetime.now(timezone.utc)
+    date_stamp = now.strftime("%Y%m%d")
+    amz_date = now.strftime("%Y%m%dT%H%M%SZ")
+    scope = f"{date_stamp}/{region}/{_STS_SERVICE}/aws4_request"
+
+    params: "dict[str, str]" = {
+        "Action": "GetCallerIdentity",
+        "Version": "2011-06-15",
+        "X-Amz-Algorithm": "AWS4-HMAC-SHA256",
+        "X-Amz-Credential": f"{access_key}/{scope}",
+        "X-Amz-Date": amz_date,
+        "X-Amz-Expires": str(expires_in),
+        "X-Amz-SignedHeaders": "host",
+    }
+    if session_token:
+        params["X-Amz-Security-Token"] = session_token
+
+    canonical_query = "&".join(
+        f"{urllib.parse.quote(k, safe='')}={urllib.parse.quote(v, safe='')}" for k, v in sorted(params.items())
+    )
+    canonical_request = "\n".join(["GET", "/", canonical_query, f"host:{host}\n", "host", _sha256_hex("")])
+    string_to_sign = "\n".join(["AWS4-HMAC-SHA256", amz_date, scope, _sha256_hex(canonical_request)])
+    signing_key = _hmac_sha256(
+        _hmac_sha256(
+            _hmac_sha256(
+                _hmac_sha256(f"AWS4{secret_key}".encode("utf-8"), date_stamp),
+                region,
+            ),
+            _STS_SERVICE,
+        ),
+        "aws4_request",
+    )
+    signature = hmac.new(signing_key, string_to_sign.encode("utf-8"), hashlib.sha256).hexdigest()
+    signed_url = f"https://{host}/?{canonical_query}&X-Amz-Signature={signature}"
+    return urlsafe_b64encode(signed_url.encode()).decode().rstrip("=")

--- a/flytekit/clients/auth/aws_sts.py
+++ b/flytekit/clients/auth/aws_sts.py
@@ -7,8 +7,7 @@ it, replays the ``GetCallerIdentity`` call against AWS STS, and trusts the
 returned principal ARN as the caller's identity.
 
 This module mints that token using only the standard library so flytekit gains
-no new dependency. It mirrors the scheme used by Exa's ``overseer`` CLI so the
-two clients produce tokens the same proxy accepts.
+no new dependency.
 """
 
 import configparser

--- a/flytekit/clients/auth_helper.py
+++ b/flytekit/clients/auth_helper.py
@@ -1,5 +1,7 @@
 import logging
+import os
 import ssl
+import typing
 from http import HTTPStatus
 
 import grpc
@@ -19,8 +21,40 @@ from flytekit.clients.auth.authenticator import (
 )
 from flytekit.clients.grpc_utils.auth_interceptor import AuthUnaryInterceptor
 from flytekit.clients.grpc_utils.default_metadata_interceptor import DefaultMetadataInterceptor
+from flytekit.clients.grpc_utils.static_metadata_interceptor import StaticMetadataInterceptor
 from flytekit.clients.grpc_utils.wrap_exception_interceptor import RetryExceptionWrapperInterceptor
 from flytekit.configuration import AuthType, PlatformConfig
+
+#: Env var carrying extra gRPC metadata to stamp on every Admin call, as a
+#: comma-separated list of ``key=value`` pairs (e.g. used to forward
+#: caller/session attribution headers to an Admin proxy). Keys are lowercased.
+STATIC_GRPC_METADATA_ENV_VAR = "FLYTE_GRPC_METADATA"
+
+
+def _static_grpc_metadata_from_env() -> typing.List[typing.Tuple[str, str]]:
+    """Parse :data:`STATIC_GRPC_METADATA_ENV_VAR` into ``(key, value)`` pairs.
+
+    Malformed entries (missing ``=``, empty key/value) are skipped so a bad env
+    value can never break channel construction.
+    """
+    raw = os.environ.get(STATIC_GRPC_METADATA_ENV_VAR, "")
+    pairs: typing.List[typing.Tuple[str, str]] = []
+    for item in raw.split(","):
+        key, sep, value = item.partition("=")
+        if not sep:
+            continue
+        key, value = key.strip(), value.strip()
+        if key and value:
+            pairs.append((key, value))
+    return pairs
+
+
+def _maybe_add_static_metadata(channel: grpc.Channel) -> grpc.Channel:
+    """Stack a :class:`StaticMetadataInterceptor` when env metadata is present."""
+    metadata = _static_grpc_metadata_from_env()
+    if metadata:
+        return grpc.intercept_channel(channel, StaticMetadataInterceptor(metadata))
+    return channel
 
 
 class RemoteClientConfigStore(ClientConfigStore):
@@ -197,7 +231,9 @@ def get_channel(cfg: PlatformConfig, **kwargs) -> grpc.Channel:
     :return: grpc.Channel (secure / insecure)
     """
     if cfg.insecure:
-        return grpc.intercept_channel(grpc.insecure_channel(cfg.endpoint, **kwargs), DefaultMetadataInterceptor())
+        return _maybe_add_static_metadata(
+            grpc.intercept_channel(grpc.insecure_channel(cfg.endpoint, **kwargs), DefaultMetadataInterceptor())
+        )
 
     credentials = None
     if "credentials" not in kwargs:
@@ -215,14 +251,16 @@ def get_channel(cfg: PlatformConfig, **kwargs) -> grpc.Channel:
             )
     else:
         credentials = kwargs["credentials"]
-    return grpc.intercept_channel(
-        grpc.secure_channel(
-            target=cfg.endpoint,
-            credentials=credentials,
-            options=kwargs.get("options", None),
-            compression=kwargs.get("compression", None),
-        ),
-        DefaultMetadataInterceptor(),
+    return _maybe_add_static_metadata(
+        grpc.intercept_channel(
+            grpc.secure_channel(
+                target=cfg.endpoint,
+                credentials=credentials,
+                options=kwargs.get("options", None),
+                compression=kwargs.get("compression", None),
+            ),
+            DefaultMetadataInterceptor(),
+        )
     )
 
 

--- a/flytekit/clients/auth_helper.py
+++ b/flytekit/clients/auth_helper.py
@@ -15,6 +15,7 @@ from flytekit.clients.auth.authenticator import (
     CommandAuthenticator,
     DeviceCodeAuthenticator,
     PKCEAuthenticator,
+    STSAuthenticator,
 )
 from flytekit.clients.grpc_utils.auth_interceptor import AuthUnaryInterceptor
 from flytekit.clients.grpc_utils.default_metadata_interceptor import DefaultMetadataInterceptor
@@ -92,6 +93,8 @@ def get_authenticator(cfg: PlatformConfig, cfg_store: ClientConfigStore) -> Auth
             command=cfg.command,
             header_key=client_cfg.header_key if client_cfg else None,
         )
+    elif cfg_auth == AuthType.STS:
+        return STSAuthenticator(endpoint=cfg.endpoint, verify=verify)
     elif cfg_auth == AuthType.DEVICEFLOW:
         return DeviceCodeAuthenticator(
             endpoint=cfg.endpoint,

--- a/flytekit/clients/grpc_utils/static_metadata_interceptor.py
+++ b/flytekit/clients/grpc_utils/static_metadata_interceptor.py
@@ -1,0 +1,55 @@
+"""gRPC client interceptor that stamps a fixed set of metadata on every call.
+
+Some deployments front Flyte Admin with a proxy that expects extra request
+metadata (gRPC/HTTP2 headers) beyond the auth token -- for example caller- or
+session-attribution headers used for routing or accounting. This interceptor
+adds a fixed set of ``(key, value)`` pairs to the metadata of every unary and
+stream call, mirroring :class:`DefaultMetadataInterceptor`.
+
+The metadata is static for the lifetime of the channel: the values are resolved
+once (typically from the environment) when the channel is built, not per call.
+This is independent of the auth flow, so it composes with any ``auth_mode``.
+"""
+
+import typing
+
+import grpc
+
+from flytekit.clients.grpc_utils.auth_interceptor import _ClientCallDetails
+
+
+class StaticMetadataInterceptor(grpc.UnaryUnaryClientInterceptor, grpc.UnaryStreamClientInterceptor):
+    def __init__(self, metadata: typing.List[typing.Tuple[str, str]]):
+        # gRPC metadata keys must be lowercase ASCII; drop pairs with empty key/value.
+        self._metadata: typing.List[typing.Tuple[str, str]] = [
+            (key.lower(), value) for key, value in metadata if key and value
+        ]
+
+    def _inject_static_metadata(self, call_details: grpc.ClientCallDetails) -> grpc.ClientCallDetails:
+        metadata = list(self._metadata)
+        if call_details.metadata:
+            metadata.extend(list(call_details.metadata))
+        return _ClientCallDetails(
+            call_details.method,
+            call_details.timeout,
+            metadata,
+            call_details.credentials,
+        )
+
+    def intercept_unary_unary(
+        self,
+        continuation: typing.Callable,
+        client_call_details: grpc.ClientCallDetails,
+        request: typing.Any,
+    ):
+        """Intercepts unary calls and injects the static metadata."""
+        return continuation(self._inject_static_metadata(client_call_details), request)
+
+    def intercept_unary_stream(
+        self,
+        continuation: typing.Callable,
+        client_call_details: grpc.ClientCallDetails,
+        request: typing.Any,
+    ):
+        """Handles a stream call and injects the static metadata."""
+        return continuation(self._inject_static_metadata(client_call_details), request)

--- a/flytekit/configuration/__init__.py
+++ b/flytekit/configuration/__init__.py
@@ -387,6 +387,9 @@ class AuthType(enum.Enum):
     BASIC = "basic"
     CLIENT_CREDENTIALS = "client_credentials"
     EXTERNAL_PROCESS = "external_process"
+    # Authenticate with an AWS STS presigned ``GetCallerIdentity`` URL as the
+    # bearer token, for Admin proxies that validate an AWS identity.
+    STS = "sts"
     # The following values are copied from flyteidl's admin client to align the two code bases on the same enum values.
     # The enum values above will continue to work.
     CLIENTSECRET = "ClientSecret"

--- a/tests/flytekit/unit/clients/auth/test_authenticator.py
+++ b/tests/flytekit/unit/clients/auth/test_authenticator.py
@@ -10,6 +10,7 @@ from flytekit.clients.auth.authenticator import (
     CommandAuthenticator,
     DeviceCodeAuthenticator,
     PKCEAuthenticator,
+    STSAuthenticator,
     StaticClientConfigStore,
 )
 from flytekit.clients.auth.exceptions import AuthenticationError, AccessTokenNotFoundError
@@ -66,6 +67,33 @@ def test_command_authenticator(mock_subprocess: MagicMock):
 
     with pytest.raises(AuthenticationError):
         authn.refresh_credentials()
+
+
+@patch("flytekit.clients.auth.aws_sts.resolve_aws_credentials")
+def test_sts_authenticator_mints_fresh_token_per_call(mock_resolve: MagicMock):
+    mock_resolve.return_value = ("AKIA", "secret", "session")
+    authn = STSAuthenticator(ENDPOINT)
+
+    header_key, value = authn.fetch_grpc_call_auth_metadata()
+    assert header_key == "authorization"
+    assert value.startswith("Bearer ")
+    # AWS credentials are resolved once and cached on the instance.
+    authn.fetch_grpc_call_auth_metadata()
+    mock_resolve.assert_called_once()
+
+
+@patch("flytekit.clients.auth.aws_sts.resolve_aws_credentials")
+def test_sts_authenticator_refresh_reresolves_credentials(mock_resolve: MagicMock):
+    mock_resolve.return_value = ("AKIA", "secret", None)
+    authn = STSAuthenticator(ENDPOINT)
+
+    authn.fetch_grpc_call_auth_metadata()
+    assert mock_resolve.call_count == 1
+
+    # refresh_credentials drops the cache so rotated credentials are picked up.
+    authn.refresh_credentials()
+    assert authn._creds is not None
+    assert mock_resolve.call_count == 2
 
 
 @patch("flytekit.clients.auth.token_client.requests.Session")

--- a/tests/flytekit/unit/clients/auth/test_aws_sts.py
+++ b/tests/flytekit/unit/clients/auth/test_aws_sts.py
@@ -1,0 +1,72 @@
+import base64
+import urllib.parse
+
+import pytest
+
+from flytekit.clients.auth.aws_sts import (
+    STSCredentialsError,
+    create_sts_token,
+    resolve_aws_credentials,
+)
+
+
+def _decode_token(token: str) -> urllib.parse.ParseResult:
+    # base64url-decode (restoring stripped padding) back to the signed URL.
+    padded = token + "=" * (-len(token) % 4)
+    signed_url = base64.urlsafe_b64decode(padded).decode()
+    return urllib.parse.urlparse(signed_url)
+
+
+def test_create_sts_token_is_presigned_get_caller_identity_url():
+    token = create_sts_token("AKIAEXAMPLE", "secret", expires_in=60)
+    parsed = _decode_token(token)
+    assert parsed.scheme == "https"
+    assert parsed.netloc == "sts.amazonaws.com"
+
+    query = urllib.parse.parse_qs(parsed.query)
+    assert query["Action"] == ["GetCallerIdentity"]
+    assert query["Version"] == ["2011-06-15"]
+    assert query["X-Amz-Algorithm"] == ["AWS4-HMAC-SHA256"]
+    assert query["X-Amz-Expires"] == ["60"]
+    assert query["X-Amz-SignedHeaders"] == ["host"]
+    assert query["X-Amz-Credential"][0].startswith("AKIAEXAMPLE/")
+    assert query["X-Amz-Credential"][0].endswith("/us-east-1/sts/aws4_request")
+    # A signature is always appended last.
+    assert len(query["X-Amz-Signature"][0]) == 64
+
+
+def test_create_sts_token_includes_session_token_when_present():
+    with_token = _decode_token(create_sts_token("ak", "sk", "session-token-123"))
+    without_token = _decode_token(create_sts_token("ak", "sk"))
+
+    assert "X-Amz-Security-Token" in urllib.parse.parse_qs(with_token.query)
+    assert "X-Amz-Security-Token" not in urllib.parse.parse_qs(without_token.query)
+
+
+def test_create_sts_token_has_no_base64_padding():
+    # The proxy expects a base64url value without trailing '=' padding.
+    assert "=" not in create_sts_token("ak", "sk")
+
+
+def test_create_sts_token_respects_region_override():
+    parsed = _decode_token(create_sts_token("ak", "sk", region="us-west-2"))
+    query = urllib.parse.parse_qs(parsed.query)
+    assert query["X-Amz-Credential"][0].endswith("/us-west-2/sts/aws4_request")
+
+
+def test_resolve_aws_credentials_from_env(monkeypatch):
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "AKIAENV")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "secretenv")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "tokenenv")
+    assert resolve_aws_credentials() == ("AKIAENV", "secretenv", "tokenenv")
+
+
+def test_resolve_aws_credentials_raises_when_unavailable(monkeypatch):
+    for var in ("AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_SESSION_TOKEN"):
+        monkeypatch.delenv(var, raising=False)
+    # Point credential/config file resolution at empty paths and disable IMDS.
+    monkeypatch.setenv("AWS_SHARED_CREDENTIALS_FILE", "/nonexistent/credentials")
+    monkeypatch.setenv("AWS_CONFIG_FILE", "/nonexistent/config")
+    monkeypatch.setattr("flytekit.clients.auth.aws_sts._credentials_from_imds", lambda: None)
+    with pytest.raises(STSCredentialsError):
+        resolve_aws_credentials()

--- a/tests/flytekit/unit/clients/grpc_utils/test_static_metadata_interceptor.py
+++ b/tests/flytekit/unit/clients/grpc_utils/test_static_metadata_interceptor.py
@@ -1,0 +1,53 @@
+from unittest.mock import MagicMock
+
+from flytekit.clients.grpc_utils.static_metadata_interceptor import StaticMetadataInterceptor
+
+
+def _call_details(metadata=None):
+    d = MagicMock()
+    d.method = "/foo.Service/Method"
+    d.timeout = None
+    d.metadata = metadata
+    d.credentials = None
+    return d
+
+
+def test_injects_metadata_when_none_present():
+    interceptor = StaticMetadataInterceptor([("agent-session-id", "abc"), ("agent-session-owner", "octocat")])
+    continuation = MagicMock()
+
+    interceptor.intercept_unary_unary(continuation, _call_details(), request="req")
+
+    passed_details = continuation.call_args.args[0]
+    assert list(passed_details.metadata) == [
+        ("agent-session-id", "abc"),
+        ("agent-session-owner", "octocat"),
+    ]
+
+
+def test_preserves_existing_metadata():
+    interceptor = StaticMetadataInterceptor([("agent-session-id", "abc")])
+    continuation = MagicMock()
+
+    interceptor.intercept_unary_stream(continuation, _call_details(metadata=[("authorization", "Bearer x")]), "req")
+
+    passed_details = continuation.call_args.args[0]
+    assert list(passed_details.metadata) == [
+        ("agent-session-id", "abc"),
+        ("authorization", "Bearer x"),
+    ]
+
+
+def test_lowercases_keys_and_drops_empty_pairs():
+    interceptor = StaticMetadataInterceptor(
+        [("Agent-Session-Id", "abc"), ("", "novalue"), ("nokey", ""), ("agent-session-owner", "octocat")]
+    )
+    continuation = MagicMock()
+
+    interceptor.intercept_unary_unary(continuation, _call_details(), request="req")
+
+    passed_details = continuation.call_args.args[0]
+    assert list(passed_details.metadata) == [
+        ("agent-session-id", "abc"),
+        ("agent-session-owner", "octocat"),
+    ]

--- a/tests/flytekit/unit/clients/test_auth_helper.py
+++ b/tests/flytekit/unit/clients/test_auth_helper.py
@@ -17,13 +17,17 @@ from flytekit.clients.auth.authenticator import (
 from flytekit.clients.auth.exceptions import AuthenticationError
 from flytekit.clients.auth_helper import (
     RemoteClientConfigStore,
+    _static_grpc_metadata_from_env,
     get_authenticator,
+    get_channel,
     get_session,
     upgrade_channel_to_authenticated,
     upgrade_channel_to_proxy_authenticated,
     wrap_exceptions_channel,
 )
 from flytekit.clients.grpc_utils.auth_interceptor import AuthUnaryInterceptor
+from flytekit.clients.grpc_utils.default_metadata_interceptor import DefaultMetadataInterceptor
+from flytekit.clients.grpc_utils.static_metadata_interceptor import StaticMetadataInterceptor
 from flytekit.clients.grpc_utils.wrap_exception_interceptor import RetryExceptionWrapperInterceptor
 from flytekit.configuration import AuthType, PlatformConfig
 
@@ -184,6 +188,38 @@ def test_upgrade_channel_to_proxy_auth():
     )
     assert isinstance(out_ch._interceptor, AuthUnaryInterceptor)
     assert isinstance(out_ch._interceptor._authenticator, CommandAuthenticator)
+
+
+def test_static_grpc_metadata_from_env_parses_pairs(monkeypatch):
+    monkeypatch.setenv("FLYTE_GRPC_METADATA", " agent-session-id=abc , agent-session-owner=octocat ")
+    assert _static_grpc_metadata_from_env() == [
+        ("agent-session-id", "abc"),
+        ("agent-session-owner", "octocat"),
+    ]
+
+
+def test_static_grpc_metadata_from_env_skips_malformed(monkeypatch):
+    monkeypatch.setenv("FLYTE_GRPC_METADATA", "noequals,=noval,nokey=,good=v")
+    assert _static_grpc_metadata_from_env() == [("good", "v")]
+
+
+def test_static_grpc_metadata_from_env_empty(monkeypatch):
+    monkeypatch.delenv("FLYTE_GRPC_METADATA", raising=False)
+    assert _static_grpc_metadata_from_env() == []
+
+
+def test_get_channel_stacks_static_metadata_when_env_set(monkeypatch):
+    monkeypatch.setenv("FLYTE_GRPC_METADATA", "agent-session-id=abc")
+    ch = get_channel(PlatformConfig(endpoint="localhost:8080", insecure=True))
+    # Outermost interceptor is the static-metadata one; the default metadata interceptor sits beneath it.
+    assert isinstance(ch._interceptor, StaticMetadataInterceptor)  # noqa
+    assert isinstance(ch._channel._interceptor, DefaultMetadataInterceptor)  # noqa
+
+
+def test_get_channel_no_static_metadata_when_env_unset(monkeypatch):
+    monkeypatch.delenv("FLYTE_GRPC_METADATA", raising=False)
+    ch = get_channel(PlatformConfig(endpoint="localhost:8080", insecure=True))
+    assert isinstance(ch._interceptor, DefaultMetadataInterceptor)  # noqa
 
 
 def test_get_proxy_authenticated_session():

--- a/tests/flytekit/unit/clients/test_auth_helper.py
+++ b/tests/flytekit/unit/clients/test_auth_helper.py
@@ -12,6 +12,7 @@ from flytekit.clients.auth.authenticator import (
     CommandAuthenticator,
     DeviceCodeAuthenticator,
     PKCEAuthenticator,
+    STSAuthenticator,
 )
 from flytekit.clients.auth.exceptions import AuthenticationError
 from flytekit.clients.auth_helper import (
@@ -139,6 +140,16 @@ def test_get_authenticator_cmd():
     assert authn
     assert isinstance(authn, CommandAuthenticator)
     assert authn._cmd == ["echo"]
+
+
+def test_get_authenticator_sts():
+    cfg = PlatformConfig(auth_mode=AuthType.STS)
+    authn = get_authenticator(cfg, get_client_config())
+    assert isinstance(authn, STSAuthenticator)
+
+    # The string form used in config files resolves to the same authenticator.
+    cfg = PlatformConfig(auth_mode="sts")
+    assert isinstance(get_authenticator(cfg, get_client_config()), STSAuthenticator)
 
 
 def test_get_authenticator_deviceflow():


### PR DESCRIPTION
## Why are the changes needed?

Some Flyte deployments front Admin with a proxy that authenticates callers by **AWS identity** — an `sts:GetCallerIdentity` presigned URL that the proxy replays server-side — rather than an OAuth2 id-token. flytekit had no auth mode that speaks this scheme, so `pyflyte`/`FlyteRemote` could not talk to such an endpoint.

Such proxies often also need **extra request metadata** beyond the auth token — e.g. caller/session-attribution headers used for routing or accounting. flytekit had no way to attach arbitrary gRPC metadata to every Admin call.

This PR adds both: an STS auth mode (`auth_mode="sts"`), and a way to stamp a fixed set of gRPC metadata on every Admin call. Both are injected at flytekit's existing transport seams, so they cover the entire Admin gRPC surface (register, list/get, create_execution, relaunch, recover) with no per-command work.

## What changes were proposed in this pull request?

**STS auth**
- **`AuthType.STS` (`"sts"`)** added to `flytekit/configuration`.
- **`STSAuthenticator`** in `flytekit/clients/auth/authenticator.py`. It mints a base64url-encoded, presigned `GetCallerIdentity` URL and returns it as `("authorization", "Bearer <token>")`. A fresh token is minted **per gRPC call** because the presigned URL is short-lived; minting is local SigV4 signing (no network). Resolved AWS credentials are cached on the instance and dropped in `refresh_credentials()` so rotated/expired credentials (SSO, IMDS, assumed-role) are re-resolved on the retry the interceptor performs on `UNAUTHENTICATED`.
- **`flytekit/clients/auth/aws_sts.py`** — self-contained token minting + credential resolution (env → shared credentials file → `aws configure export-credentials` for SSO/`credential_process` → IMDSv2). Uses only the standard library, so **flytekit gains no new dependency**.
- **`get_authenticator`** wires `AuthType.STS` → `STSAuthenticator`. The STS path ignores the `ClientConfigStore`, so it works against endpoints that don't serve `AuthMetadataService`.

**Static gRPC metadata**
- **`StaticMetadataInterceptor`** in `flytekit/clients/grpc_utils/static_metadata_interceptor.py` — a client interceptor (mirroring `DefaultMetadataInterceptor`) that prepends a fixed list of `(key, value)` pairs to the metadata of every unary/stream call. Keys are lowercased per gRPC rules; empty pairs are dropped. Independent of auth, so it composes with any `auth_mode`.
- **`get_channel`** stacks it when the env var `FLYTE_GRPC_METADATA` is set — a comma-separated list of `key=value` pairs. The values are resolved once at channel construction (static for the channel lifetime), not per call. Malformed entries are skipped so a bad value can't break channel construction.

Sketch:

```python
# STS auth: fresh token per call, drop cached creds on auth failure for rotation
class STSAuthenticator(Authenticator):
    def fetch_grpc_call_auth_metadata(self):
        return self._header_key, f"Bearer {self._mint_token()}"
    def refresh_credentials(self):
        self._aws_credentials = None
        self._set_credentials(Credentials(self._mint_token()))

# usage
Config(platform=PlatformConfig(endpoint=..., auth_mode="sts"))

# extra metadata on every Admin call
os.environ["FLYTE_GRPC_METADATA"] = "agent-session-id=<id>,agent-session-owner=<login>"
```

## How was this patch tested?

Added unit tests (46 passing across the touched suites):

- `tests/.../auth/test_aws_sts.py` — token decodes to a presigned `GetCallerIdentity` URL with the expected SigV4 query params/signature, `X-Amz-Security-Token` present only when a session token exists, base64url has no padding, region override honored, env credential resolution, and `STSCredentialsError` when no source yields credentials.
- `test_authenticator.py` — `STSAuthenticator` mints fresh per call, caches credential resolution, and re-resolves after `refresh_credentials()`.
- `tests/.../grpc_utils/test_static_metadata_interceptor.py` — metadata injected when none present, existing metadata preserved, keys lowercased and empty pairs dropped.
- `test_auth_helper.py` — `get_authenticator` returns `STSAuthenticator` for `AuthType.STS` and `"sts"`; `FLYTE_GRPC_METADATA` parsing (pairs, malformed-skipped, empty); `get_channel` stacks `StaticMetadataInterceptor` when the env var is set and not otherwise.

```
python -m pytest tests/flytekit/unit/clients/auth/ \
  tests/flytekit/unit/clients/test_auth_helper.py \
  tests/flytekit/unit/clients/grpc_utils/ -q
# 46 passed
```

`ruff check` and `ruff format` clean on all new/edited files.

## Check all the applicable boxes

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [ ] All commits are signed-off.

## Notes for reviewers

- STS auth only handles **authentication**, and the metadata interceptor only **forwards** whatever the client sets. Any server-authoritative attribution / anti-spoof (e.g. validating or overriding those headers, stripping client-provided labels) still has to live server-side — either in the validating proxy or a FlyteAdmin-side interceptor. This PR does not address that.
- `FLYTE_GRPC_METADATA` is intentionally generic (no product semantics) — the caller decides what headers to send. The values are static per channel; this is meant for process-constant attribution (e.g. a session id/owner), not per-request data.
- Region/host/expiry for STS currently default to the global STS endpoint + 60s; these are constructor args on `STSAuthenticator` if we later want to surface them through `PlatformConfig`.

Link to Devin session: https://app.devin.ai/sessions/5077169677584d02b061e529ccde0fbc
Requested by: @pfernandes21